### PR TITLE
Fix test setup and doc instructions

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -28,6 +28,13 @@ jobs:
         uv venv
         source .venv/bin/activate
         uv pip install -e .[dev]
+    - name: Cache embedding model
+      run: |
+        source .venv/bin/activate
+        python - <<'EOF'
+from sentence_transformers import SentenceTransformer
+SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
+EOF
     - name: Lint with ruff
       run: |
         source .venv/bin/activate
@@ -36,4 +43,4 @@ jobs:
     - name: Test with pytest
       run: |
         source .venv/bin/activate
-        pytest
+        TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1 pytest

--- a/SETUP.md
+++ b/SETUP.md
@@ -160,3 +160,24 @@ uvicorn rag_pipeline.api.main:app --reload
 - **`uv` command not found**: Ensure `uv` is installed and its installation directory is in your system's PATH. Refer to the official `uv` installation guide.
 - **Python version issues**: Make sure you have Python 3.12 installed and that `uv` is using it. You can specify the Python version for `uv venv` using `uv venv -p 3.12`.
 - **Pre-commit hook failures**: Address the issues reported by the hooks (e.g., formatting errors, linting violations) and re-commit.
+
+## Offline model caching
+
+The tests rely on the `sentence-transformers/all-MiniLM-L6-v2` model. If you are
+working in an environment without internet access you must download this model
+in advance and cache it locally:
+
+```bash
+python - <<'EOF'
+from sentence_transformers import SentenceTransformer
+SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
+EOF
+```
+
+The files are stored under `~/.cache/huggingface` by default. Afterwards you can
+set the following environment variables to avoid network calls:
+
+```bash
+export TRANSFORMERS_OFFLINE=1
+export HF_DATASETS_OFFLINE=1
+```

--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -1,16 +1,28 @@
+from pathlib import Path
+
 from fastapi.testclient import TestClient
 
 from auth_service.main import app
 
-client = TestClient(app)
+# Remove the SQLite database between test runs to ensure a clean state
+DB_PATH = Path(__file__).resolve().parents[1] / "src" / "auth_service" / "auth.db"
 
 
 def test_register_and_login() -> None:
-    resp = client.post("/register", json={"username": "alice", "email": "a@example.com", "password": "secret"})
-    assert resp.status_code == 200
-    token_resp = client.post("/login", json={"username": "alice", "password": "secret"})
-    assert token_resp.status_code == 200
-    token = token_resp.json()["token"]
-    me = client.get("/me", headers={"Authorization": f"Bearer {token}"})
-    assert me.status_code == 200
-    assert me.json()["username"] == "alice"
+    if DB_PATH.exists():
+        DB_PATH.unlink()
+    with TestClient(app) as client:
+        resp = client.post(
+            "/register",
+            json={"username": "alice", "email": "a@example.com", "password": "secret"},
+        )
+        assert resp.status_code == 200
+        token_resp = client.post(
+            "/login",
+            json={"username": "alice", "password": "secret"},
+        )
+        assert token_resp.status_code == 200
+        token = token_resp.json()["token"]
+        me = client.get("/me", headers={"Authorization": f"Bearer {token}"})
+        assert me.status_code == 200
+        assert me.json()["username"] == "alice"


### PR DESCRIPTION
## Summary
- ensure database is created for auth service test
- add offline model caching instructions
- pre-download embedding model in CI so tests run offline

## Testing
- `ruff check . && ruff format --check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'llama_index')*

------
https://chatgpt.com/codex/tasks/task_b_6845eb33143c832fbf7d12e9dbaf33a7