### PR TITLE
Add monetization feature docs and subscription tests

### DIFF
--- a/docs/technical/MONETIZATION.md
+++ b/docs/technical/MONETIZATION.md
@@ -1,0 +1,29 @@
+# Monetization Approach
+
+This document outlines simple monetization options and anti-abuse controls for the project.
+
+## Options
+
+- **Paid usage**: charge per API call or per uploaded document.
+- **Subscription**: associate each user with an expiration date.
+- **Lifetime license**: flag a user as exempt from subscription checks.
+
+## Implementation Hints
+
+- Add a `subscription_expires` field to the `User` model.
+- Validate the subscription for each request in middleware.
+- Use UTC time from the server to prevent client-side time manipulation.
+- Consider storing request timestamps and rate limiting.
+
+### Anti-abuse Controls
+
+- Reject requests when the client timestamp deviates too much from the server time.
+- Re-check subscription status on every authenticated request.
+
+## References
+
+- [FastAPI Middleware](https://fastapi.tiangolo.com/tutorial/middleware/)
+
+## Code Files
+
+- [src/backend/monetization/subscription.py](../../src/backend/monetization/subscription.py) - Subscription validity helpers

--- a/project/program/features/FEAT-007.md
+++ b/project/program/features/FEAT-007.md
@@ -1,0 +1,34 @@
+# Feature: Monetization Controls
+
+**ID**: FEAT-007
+**Epic**: [EPIC-001: On-Premises RAG Foundation](../../portfolio/epics/EPIC-001.md)
+**ART**: Data Intelligence Platform
+**Status**: Backlog
+**Priority**: Should Have
+**Created**: 2025-06-07
+**Updated**: 2025-06-07
+
+## Description
+Implement simple paid usage and subscription expiration. Requests from users with expired subscriptions are rejected, and timestamps are validated to prevent abuse.
+
+## Business Value
+
+**Revenue Stream**: Enables cost recovery through subscriptions
+**Abuse Prevention**: Limits access to authorized users
+
+### Key Outcomes
+- Subscription expiry enforcement
+- Usage tracking for pay-per-use
+- Timestamp validation middleware
+
+## User Stories
+- [ ] **[STORY-010: Subscription Validation](../../team/stories/STORY-010.md)**: As a system, I need to verify subscriptions
+
+## Acceptance Criteria
+- [ ] Subscription checked on each authenticated request
+- [ ] Timestamps validated against server time
+- [ ] Tests cover expiration and timestamp checks
+
+## Definition of Done
+- [ ] All tasks implemented and tests pass
+- [ ] Documentation updated

--- a/project/team/stories/STORY-010.md
+++ b/project/team/stories/STORY-010.md
@@ -1,0 +1,35 @@
+# User Story: Subscription Validation
+
+**ID**: STORY-010
+**Feature**: [FEAT-007: Monetization Controls](../../program/features/FEAT-007.md)
+**Team**: Backend Engineering
+**Status**: Backlog
+**Priority**: P2
+**Points**: 3
+**Created**: 2025-06-07
+**Updated**: 2025-06-07
+
+## User Story
+As a **system**,
+I want **to verify that a user's subscription has not expired**,
+So that **only paying users can access the API**.
+
+## Business Context
+Paid features require enforcing subscription status on every request.
+
+## Acceptance Criteria
+- [ ] Requests from expired users return HTTP 402
+- [ ] Valid subscriptions allow normal access
+- [ ] Timestamps outside the allowed window return HTTP 400
+
+## Solution Approach
+Add middleware that checks `subscription_expires` and validates the `X-Client-Time` header.
+
+## Tasks
+- [ ] **[TASK-023](../tasks/TASK-023.md)**: Add subscription utilities and tests
+- [ ] **[TASK-024](../tasks/TASK-024.md)**: Implement timestamp middleware
+
+## Definition of Done
+- [ ] Unit tests >80% coverage
+- [ ] Linting and formatting pass
+- [ ] Documentation updated

--- a/project/team/tasks/TASK-023.md
+++ b/project/team/tasks/TASK-023.md
@@ -1,0 +1,32 @@
+# Task: Add Subscription Utilities and Tests
+
+**ID**: TASK-023
+**Story**: [STORY-010: Subscription Validation](../stories/STORY-010.md)
+**Assignee**: Backend Developer
+**Status**: Todo
+**Effort**: 4 hours
+**Created**: 2025-06-07
+**Updated**: 2025-06-07
+
+## Description
+Create helper functions to validate subscription expiry and request timestamps. Add pytest covering expected scenarios.
+
+## Implementation Hints
+- Add module `backend/monetization/subscription.py`
+- Implement `is_subscription_active` and `is_request_time_reasonable`
+- Write tests in `tests/test_subscription.py`
+- Reference design in [MONETIZATION.md](../../docs/technical/MONETIZATION.md)
+
+## Acceptance Criteria
+- [ ] Functions return correct boolean results
+- [ ] Tests verify expiry and timestamp tolerance
+- [ ] Documentation updated
+
+## Dependencies
+- **Blocked by**: None
+- **Blocks**: TASK-024
+
+---
+**Implementer**: Backend Developer
+**Reviewer**: Lead Developer
+**Target Completion**: TBD

--- a/project/team/tasks/TASK-024.md
+++ b/project/team/tasks/TASK-024.md
@@ -1,0 +1,32 @@
+# Task: Implement Timestamp Middleware
+
+**ID**: TASK-024
+**Story**: [STORY-010: Subscription Validation](../stories/STORY-010.md)
+**Assignee**: Backend Developer
+**Status**: Todo
+**Effort**: 6 hours
+**Created**: 2025-06-07
+**Updated**: 2025-06-07
+
+## Description
+Add FastAPI middleware that checks the `X-Client-Time` header and rejects requests if the timestamp is unreasonable or the subscription has expired.
+
+## Implementation Hints
+- Retrieve user and verify `subscription_expires`
+- Compare header timestamp using `is_request_time_reasonable`
+- Return HTTP 402 for expired subscriptions
+- Return HTTP 400 for invalid timestamps
+
+## Acceptance Criteria
+- [ ] Middleware rejects invalid or expired requests
+- [ ] Tests cover success and failure cases
+- [ ] Documentation updated
+
+## Dependencies
+- **Blocked by**: TASK-023
+- **Blocks**: None
+
+---
+**Implementer**: Backend Developer
+**Reviewer**: Lead Developer
+**Target Completion**: TBD

--- a/src/backend/monetization/__init__.py
+++ b/src/backend/monetization/__init__.py
@@ -1,0 +1,5 @@
+"""Monetization utilities."""
+
+from .subscription import is_request_time_reasonable, is_subscription_active
+
+__all__ = ["is_subscription_active", "is_request_time_reasonable"]

--- a/src/backend/monetization/subscription.py
+++ b/src/backend/monetization/subscription.py
@@ -1,0 +1,21 @@
+"""Subscription helpers.
+
+See docs/technical/MONETIZATION.md for usage details.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+
+def is_subscription_active(expires_at: datetime, *, now: datetime | None = None) -> bool:
+    """Return ``True`` if the subscription has not expired."""
+    current = now or datetime.utcnow()
+    return current <= expires_at
+
+
+def is_request_time_reasonable(
+    client_time: datetime, server_time: datetime, *, tolerance: timedelta = timedelta(minutes=5)
+) -> bool:
+    """Return ``True`` if the client timestamp is within ``tolerance`` of server time."""
+    return abs(server_time - client_time) <= tolerance

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -1,0 +1,34 @@
+"""Tests for subscription utilities."""
+
+from datetime import datetime, timedelta
+
+from backend.monetization.subscription import (
+    is_request_time_reasonable,
+    is_subscription_active,
+)
+
+
+def test_subscription_active_true() -> None:
+    """Subscription should be active when expiry is in the future."""
+    expires_at = datetime.utcnow() + timedelta(days=1)
+    assert is_subscription_active(expires_at)
+
+
+def test_subscription_active_false() -> None:
+    """Subscription should be inactive after expiration."""
+    expires_at = datetime.utcnow() - timedelta(seconds=1)
+    assert not is_subscription_active(expires_at)
+
+
+def test_request_time_reasonable() -> None:
+    """Client timestamp within tolerance should pass."""
+    server_time = datetime.utcnow()
+    client_time = server_time - timedelta(minutes=2)
+    assert is_request_time_reasonable(client_time, server_time)
+
+
+def test_request_time_unreasonable() -> None:
+    """Client timestamp outside tolerance should fail."""
+    server_time = datetime.utcnow()
+    client_time = server_time - timedelta(minutes=10)
+    assert not is_request_time_reasonable(client_time, server_time, tolerance=timedelta(minutes=5))


### PR DESCRIPTION
## Summary
- document monetization options and anti-abuse controls
- add Monetization feature, story, and tasks
- implement basic subscription helper utilities
- add pytest tests for subscription logic

## Testing
- `ruff check src/backend/monetization/subscription.py tests/test_subscription.py`
- `ruff format src/backend/monetization/subscription.py tests/test_subscription.py`
- `pytest -q` *(fails: ModuleNotFoundError: httpx, llama_index, fastapi, jose)*

------
https://chatgpt.com/codex/tasks/task_b_684ae6fd94d4832fb736d5a4109fa11b