### PR TITLE
Add top-level planning docs

### DIFF
--- a/DOMAIN_DRIVEN_DESIGN.md
+++ b/DOMAIN_DRIVEN_DESIGN.md
@@ -1,0 +1,65 @@
+# Domain Driven Design: On-Premises RAG Solution
+
+## Domain Overview
+
+The system ingests enterprise documents and makes them searchable through a
+Retrieval‑Augmented Generation workflow. It exposes a web API and UI for
+questions, returning answers with source citations. The architecture prioritizes
+local execution and security.
+
+## Bounded Contexts
+
+- **Document Processing** – loaders, chunking and embeddings
+- **Vector Store** – manages document chunks and search
+- **LLM Provider** – abstraction over Ollama, llama.cpp and others
+- **Query Service** – combines retrieval and LLM answer generation
+- **User Interface** – React frontend for upload and chat
+- **Security** – authentication, authorization and audit logging
+- **Deployment** – Docker, monitoring and CI/CD
+
+## Key Entities
+
+| Entity    | Description                                    |
+|-----------|------------------------------------------------|
+| Document  | Uploaded file with metadata                    |
+| Chunk     | Portion of a document stored for search        |
+| Embedding | Vector representation of a chunk               |
+| Query     | User question to be answered                   |
+| Answer    | LLM response with citations                    |
+| User      | Authenticated actor with roles                 |
+| Role      | Permission set used by RBAC                    |
+
+## Component Responsibilities
+
+- **DocumentLoader** – validates and extracts text
+- **Chunker** – splits text using configured strategy
+- **Embeddings** – generates vectors via sentence transformers
+- **VectorStoreManager** – stores and retrieves embeddings
+- **LLMProviderFactory** – creates provider instances
+- **SecurityManager** – JWT handling and role enforcement
+- **Web API** – FastAPI endpoints and streaming responses
+- **Frontend** – React components for upload and Q&A
+
+## Data Flow
+
+1. User uploads document through the UI.
+2. Backend processes file into chunks and embeddings.
+3. Embeddings stored in ChromaDB via VectorStoreManager.
+4. User submits question to `/ask` endpoint.
+5. Query Service retrieves relevant chunks.
+6. LLMProvider generates answer from context.
+7. Response streamed back with citations.
+
+## References
+
+- [docs/technical/CHUNKING.md](docs/technical/CHUNKING.md)
+- [docs/technical/EMBEDDING.md](docs/technical/EMBEDDING.md)
+- [docs/technical/LLM.md](docs/technical/LLM.md)
+- [docs/technical/VECTOR_STORE.md](docs/technical/VECTOR_STORE.md)
+
+## Code Files
+
+- [src/backend/rag_pipeline/file_ingestion.py](src/backend/rag_pipeline/file_ingestion.py) – High‑level file processing API
+- [src/backend/rag_pipeline/core/vector_store.py](src/backend/rag_pipeline/core/vector_store.py) – ChromaDB integration
+- [src/backend/rag_pipeline/core/embeddings.py](src/backend/rag_pipeline/core/embeddings.py) – Embedding generation
+- [src/backend/security/security_manager.py](src/backend/security/security_manager.py) – JWT utilities

--- a/PRODUCT_REQUIREMENTS_DOCUMENT.md
+++ b/PRODUCT_REQUIREMENTS_DOCUMENT.md
@@ -1,0 +1,63 @@
+# Product Requirements Document: On-Premises RAG Solution
+
+## Overview
+
+The On-Premises RAG Solution allows organizations to use large language models
+for document analysis and database queries while keeping all data within their
+infrastructure. The product removes cloud dependencies and supports strict
+compliance needs.
+
+## Objectives
+
+- Provide offline document ingestion and question answering
+- Deliver an intuitive interface for uploading documents and asking questions
+- Support multiple local LLM backends for future flexibility
+- Offer optional natural language to SQL capabilities
+- Ensure enterprise-grade security and deployment tooling
+
+## Key Features
+
+1. **Technical Foundation & MVP** – core document pipeline and Q&A interface
+2. **Enterprise User Interface** – web UI with upload and chat features
+3. **Flexible LLM Integration** – modular provider system for multiple models
+4. **Database Query Capabilities** – NL2SQL after document Q&A is stable
+5. **Production Deployment** – Docker-based deployment and monitoring
+6. **Security Framework** – network isolation, RBAC, audit logging
+
+## Non‑Functional Requirements
+
+- Works fully offline without external calls
+- Compatible with Python 3.11+ and modern browsers
+- Docker containers for consistent environments
+- Unit and integration tests with >80% coverage
+- Role-based access control and encrypted traffic
+
+## Milestones
+
+- **Phase 1**: Document Q&A MVP (Features 001–002)
+- **Phase 2**: Flexible LLM and deployment tooling (Features 003, 005)
+- **Phase 3**: Security hardening and database queries (Features 004, 006)
+
+## Success Metrics
+
+- <5 second response time for document Q&A
+- 80%+ monthly active users from target group
+- 99.9% uptime after production launch
+- Eliminate $50k+ annual cloud AI costs
+
+## Risks
+
+- **Model Performance** – mitigate with benchmarking and fallback models
+- **Security Vulnerabilities** – require third‑party security audit
+- **Scalability** – plan horizontal scaling for heavy workloads
+
+## References
+
+- [README.md](README.md)
+- [project/SAFe Project Plan.md](project/SAFe%20Project%20Plan.md)
+- [project/portfolio/epics/EPIC-001.md](project/portfolio/epics/EPIC-001.md)
+- [project/program/features/](project/program/features/)
+
+## Code Files
+
+_Intentionally left empty – no direct code dependencies_

--- a/PROJECT_MANAGER.md
+++ b/PROJECT_MANAGER.md
@@ -1,0 +1,40 @@
+# Project Manager Overview
+
+## Implementation Phases
+
+1. **Foundation** – Complete Features 001 and 002
+   - Stories 001‑004 cover environment setup, document pipeline and basic Q&A
+   - Frontend stories 006‑007 implement upload and chat interface
+2. **LLM and Deployment** – Features 003 and 005
+   - Story 010‑014 implement modular LLM providers and Q&A API
+   - Stories 020‑024 deliver containerization, CI/CD and monitoring
+3. **Security and Database** – Features 004 and 006
+   - Stories 015‑019 create NL2SQL pipeline and connectors
+   - Stories 025‑029 enforce security framework and compliance
+
+## Task Grouping
+
+| Sprint | Primary Focus                     | Key Tasks                                     |
+|-------|----------------------------------|-----------------------------------------------|
+| 1     | Dev environment & pipeline       | TASK‑001 … TASK‑009                           |
+| 2     | Q&A endpoint & Docker workflow   | TASK‑010 … TASK‑017                           |
+| 3     | Upload UI & integration          | TASK‑018 … TASK‑023                           |
+| 4     | LLM provider and monitoring      | future tasks from Feature 003 and 005         |
+| 5     | Security hardening               | tasks from Feature 006                        |
+| 6     | NL2SQL and advanced features     | tasks from Feature 004                        |
+
+## Progress Tracking
+
+- Completed: TASK‑001, TASK‑002, TASK‑003, TASK‑023
+- In Progress: STORY‑001, STORY‑002, STORY‑003, STORY‑004
+- Upcoming: FEATURE 003+ tasks and security stories
+
+## References
+
+- [project/program/features/](project/program/features/)
+- [project/team/stories/](project/team/stories/)
+- [project/team/tasks/](project/team/tasks/)
+
+## Code Files
+
+_Intentionally left empty – no direct code dependencies_


### PR DESCRIPTION
## Summary
- add product requirements document for CEO view
- document domain-driven design for system architecture
- create project manager overview of tasks and phases

## Testing
- `pre-commit run --files PRODUCT_REQUIREMENTS_DOCUMENT.md DOMAIN_DRIVEN_DESIGN.md PROJECT_MANAGER.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_685111c0f6fc832fb6ee703f75c85c90