### PR TITLE
Introduce shared AI guidance

### DIFF
--- a/.cursor/rules/golden-rules.mdc
+++ b/.cursor/rules/golden-rules.mdc
@@ -5,6 +5,7 @@ alwaysApply: true
 ---
 # Golden Rules for AI Coding Assistance
 
+For consolidated guidance see [agents/README.md](../../agents/README.md).
 This guide outlines the key principles and practices for AI-assisted development in our SAFe environment.
 
 ## Core Principles

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # AGENTS.md
 
+## Shared Guidance
+
+For consolidated rules see [agents/README.md](agents/README.md).
+
 ## Codex Integration Example
 
 This document provides a practical example of how OpenAI Codex is integrated into our project to enhance productivity and streamline coding tasks.
@@ -135,3 +139,7 @@ When implementing tasks:
 - Document any deviations from original requirements
 - Include testing instructions and results
 - Note any dependencies or prerequisites
+
+## Related Guidance
+
+See [agents/README.md](agents/README.md) for links to coding style, documentation style, project management and architecture rules.

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,0 +1,9 @@
+# AI Shared Guidance
+
+This directory serves as the shared source of truth for all AI assisted coding and project management guidelines. Files in this directory are referenced by both `AGENTS.md` and `.cursor/rules`.
+
+- `coding_style.md` – Python and documentation style conventions
+- `documentation_style.md` – how to reference code and docs
+- `project_management.md` – SAFe based workflow guidance
+- `technical_decisions.md` – key technical standards such as dependency handling
+- `architecture.md` – target Domain Driven Design architecture

--- a/agents/architecture.md
+++ b/agents/architecture.md
@@ -1,0 +1,27 @@
+# Target DDD Architecture
+
+This project is organized around a domain-driven design. The following bounded contexts define the target structure.
+
+## Domain: Knowledge Retrieval
+
+### Subdomains and Bounded Contexts
+
+1. **Document Processing** – ingestion, chunking and embedding generation
+2. **Vector Store** – managing embeddings and search
+3. **LLM Provider** – interfacing with local LLMs
+4. **Query Service** – orchestrates retrieval and answer generation
+5. **Security** – authentication and role-based access
+
+## Key Entities
+
+| Entity | Description |
+|--------|-------------|
+| Document | Uploaded file metadata |
+| Chunk | Text slice stored in the vector store |
+| Embedding | Vector representation of a chunk |
+| Query | User question to answer |
+| Answer | LLM response with citations |
+| User | Authenticated actor |
+| Role | Permission set |
+
+Source directories under `src/` should align to these contexts when new code is added.

--- a/agents/coding_style.md
+++ b/agents/coding_style.md
@@ -1,0 +1,8 @@
+# Coding Style
+
+These guidelines summarise the coding standards enforced by the project.
+
+- Use `uv add` to manage dependencies; never use `pip install` directly.
+- Python files follow ruff linting rules with a line length of 132.
+- Keep files under 500 lines. Split modules when necessary.
+- Include links to relevant documentation in module docstrings.

--- a/agents/documentation_style.md
+++ b/agents/documentation_style.md
@@ -1,0 +1,6 @@
+# Documentation Style
+
+- Technical docs live under `docs/technical/`.
+- Project management artifacts live in `project/`.
+- Always include a `## Code Files` section linking to relevant modules.
+- Keep AGENTS and Cursor rules in sync by referencing this directory.

--- a/agents/project_management.md
+++ b/agents/project_management.md
@@ -1,0 +1,8 @@
+# Project Management
+
+The project follows SAFe practices. Key expectations:
+
+- Track work in `project/` using epics, features, stories and tasks.
+- Maintain clear acceptance criteria and update status regularly.
+- Reference parent work items to preserve traceability.
+- Use sprint demo templates from `project/team/demos/templates/`.

--- a/agents/technical_decisions.md
+++ b/agents/technical_decisions.md
@@ -1,0 +1,6 @@
+# Technical Decisions
+
+- Use FastAPI for backend APIs and React for the frontend.
+- Keep dependencies in `pyproject.toml` and install via `uv add`.
+- Source code resides in `src/` with backend and frontend packages.
+- Follow `docs/technical/DOMAIN_DRIVEN_DESIGN.md` for architecture references.


### PR DESCRIPTION
## Summary
- create a new `agents/` directory as shared reference for AGENTS.md and Cursor rules
- link AGENTS.md and `.cursor/rules/golden-rules.mdc` to the new directory
- outline DDD target architecture and split guidelines into coding, documentation, project management and technical decisions

## Testing
- `uv pip install --quiet pytest`
- `uv run pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_68541cbdd6b4832f9dd741de4391d858