### PR TITLE
docs: expand hours goal and log capture phase

### DIFF
--- a/docs/project/hours/PROJECT_PLAN.md
+++ b/docs/project/hours/PROJECT_PLAN.md
@@ -2,7 +2,12 @@
 
 ## Project Overview
 
-**Goal**: Retrofit WBSO hours registration across multiple repositories to reach/exceed 510 hours target by capturing both GitHub commits and issue creation/management activities.
+**Goal**:
+
+- Retrofit WBSO hours registration across multiple repositories to reach or exceed the 510-hour target by capturing GitHub commits and issue creation/management activities.
+- Use the hours-registration project as a worked example and use case for agentic development, aiming for a 100% accurate AI agent with curated inputs and outputs.
+- Document that initial hours registration started but paused after a few weeks pending project approval; those early records serve as ground truth for agent development.
+- Develop agent skills for new use cases such as interpreting local computer event logs for sign-on/sign-off events from natural language, without granting external or cloud agents direct access to the computer.
 
 **Scope**: Multi-repository analysis including development work, documentation, investigation, and work analysis tasks.
 
@@ -28,6 +33,7 @@
 4. **Time Validation**: Realistic time allocations with proper breaks
 5. **Approved Task Alignment**: Focus on technical development tasks that align with WBSO project goals
 6. **Technical Innovation Documentation**: Document technical challenges and innovative solutions
+7. **Verifiable Micro-Agents**: Implement small, focused AI agents with clear prompts and minimal tools so their transformations mirror example scripts.
 
 ## Current State Analysis
 
@@ -828,6 +834,7 @@ Based on your specific WBSO project "AI Agent Communicatie in een data-veilige e
 - **GitHub API Rate Limits**: Implement rate limiting and caching
 - **Repository Access Issues**: Maintain backup access methods
 - **Data Quality Issues**: Implement validation and error handling
+- **Incomplete Commit Coverage**: Prototypes or failed work may never be committed, leading to underreported hours. *Mitigation*: supplement commit data with sources like workstation login/logout logs or local file change histories.
 
 ### Compliance Risks
 
@@ -898,3 +905,11 @@ Based on your specific WBSO project "AI Agent Communicatie in een data-veilige e
    - Documentation completeness
 
 This project plan provides a comprehensive framework for achieving your 510+ hour WBSO target while maintaining compliance and creating a professional audit trail.
+
+## References
+
+- [README.md](README.md)
+
+## Code Files
+
+- [docs/project/hours/process_commits.py](docs/project/hours/process_commits.py) - Single-repository commit processing example.

--- a/docs/project/hours/README.md
+++ b/docs/project/hours/README.md
@@ -85,19 +85,25 @@ python process_commits.py
 2. Set up GitHub API access tokens
 3. Extract commit history from all repositories
 
-#### Phase 2: GitHub Issue Analysis
+#### Phase 2: Supplementary Activity Capture
+
+1. Identify gaps where commit history may miss discarded or uncommitted work.
+2. Collect supplementary sources such as workstation login/logout logs to capture complete effort.
+3. Reconcile these events with commit timelines to produce a realistic WBSO ground truth.
+
+#### Phase 3: GitHub Issue Analysis
 
 1. Extract issues using GitHub API
 2. Categorize issues by type and complexity
 3. Assign realistic hour allocations
 
-#### Phase 3: Multi-Repository Integration
+#### Phase 4: Multi-Repository Integration
 
 1. Combine all repository data
 2. Detect cross-repository work sessions
 3. Optimize hour allocations to reach 510+ target
 
-#### Phase 4: Dedicated WBSO Google Calendar and Conflict Detection
+#### Phase 5: Dedicated WBSO Google Calendar and Conflict Detection
 
 1. Create dedicated "WBSO Activities" Google Calendar
 2. Implement color coding for WBSO vs non-declarable activities
@@ -106,11 +112,24 @@ python process_commits.py
 5. Include proper descriptions and WBSO categorization
 6. Set up manual calendar export and review processes
 
-#### Phase 5: Final Reporting
+#### Phase 6: Final Reporting
 
 1. Generate comprehensive WBSO reports
 2. Validate compliance and time allocations
 3. Create final documentation package
+
+## AI Agent Implementation
+
+### Agent Prompts and Tools
+
+- Use existing scripts as ground truth for transformations.
+- Example prompt: "Given git_commit_history.txt, run process_commits.py to generate commit_analysis.txt, weekly_summary.txt, and wbso_activities.txt."
+- Required tools: `git` for history extraction and `python` for running analysis scripts.
+
+### Design Principles
+
+- Keep agents small and focused on single tasks.
+- Ensure outputs can be directly compared to script-generated files for easy verification.
 
 ## Features
 
@@ -286,3 +305,12 @@ The generated documentation includes:
 - Manual WBSO calendar maintenance and updates
 - Regular compliance validation and updates
 - Calendar export and review process maintenance
+
+## References
+
+- [PROJECT_PLAN.md](PROJECT_PLAN.md)
+
+## Code Files
+
+- [docs/project/hours/process_commits.py](docs/project/hours/process_commits.py) - Single-repository commit processing example.
+- [docs/project/hours/scripts/](docs/project/hours/scripts/) - Helper scripts for multi-repository extraction.


### PR DESCRIPTION
## Summary
- clarify project goals with bullet points referencing agentic development and ground-truth hours
- add supplementary activity capture phase using workstation logs in hours workflow

## Testing
- `uv run pre-commit run --files docs/project/hours/PROJECT_PLAN.md docs/project/hours/README.md`
- `uv run pytest` *(fails: requests.exceptions.ProxyError: MaxRetryError)*

------
https://chatgpt.com/codex/tasks/task_b_68a2bac5aed8832faef6cd8cbd6b82c5