### PR TITLE
#80: Complete FastAPI REST API - DELETE, POST /chat, GET /metrics, RFC 7807, rate limit, correlation IDs

### DIFF
--- a/src/backend/rag_pipeline/api/ask.py
+++ b/src/backend/rag_pipeline/api/ask.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field
 
 from ..core.qa_system import QASystem
 from ..utils.logging import StructuredLogger
+from .metrics import get_metrics
 
 logger = StructuredLogger(__name__)
 router = APIRouter(prefix="/api/ask", tags=["question-answering"])
@@ -72,6 +73,7 @@ async def ask_question(payload: AskRequest) -> AskResponse:
         raise HTTPException(status_code=400, detail="Question must not be empty")
 
     try:
+        get_metrics().record_query()
         logger.info("Processing question", question=payload.question)
 
         # Use QA system to answer the question

--- a/src/backend/rag_pipeline/api/chat.py
+++ b/src/backend/rag_pipeline/api/chat.py
@@ -1,0 +1,125 @@
+"""Conversational chat API endpoint for the RAG pipeline.
+
+Implements POST /api/chat with message history for multi-turn RAG conversations.
+"""
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from ..core.qa_system import QASystem
+from ..utils.logging import StructuredLogger
+from .metrics import get_metrics
+
+logger = StructuredLogger(__name__)
+router = APIRouter(prefix="/api/chat", tags=["chat"])
+
+qa_system = QASystem()
+
+
+class ChatMessage(BaseModel):
+    """Single message in a conversation."""
+
+    role: str = Field(..., description="Role: 'user' or 'assistant'")
+    content: str = Field(..., description="Message content")
+
+
+class ChatRequest(BaseModel):
+    """Request payload for the chat endpoint."""
+
+    messages: list[ChatMessage] = Field(
+        ...,
+        min_length=1,
+        description="Conversation history. Last message should be from user.",
+    )
+    top_k: int = Field(default=5, ge=1, le=20, description="Number of chunks to retrieve")
+    similarity_threshold: float = Field(default=0.7, ge=0.0, le=1.0, description="Minimum similarity score")
+
+
+class ChatResponse(BaseModel):
+    """Response payload for the chat endpoint."""
+
+    answer: str
+    sources: list[dict]
+    confidence: str
+    chunks_retrieved: int
+    average_similarity: float
+
+
+@router.post("", response_model=ChatResponse)
+async def chat(payload: ChatRequest) -> ChatResponse:
+    """Conversational RAG: answer with message history context.
+
+    Uses the last user message for retrieval. Prior messages provide context
+    for the LLM to generate coherent multi-turn responses.
+
+    Args:
+        payload: Chat request with messages and optional parameters
+
+    Returns:
+        ChatResponse with answer and sources
+
+    Raises:
+        HTTPException: If last message is not from user or processing fails
+    """
+    if not payload.messages:
+        raise HTTPException(status_code=400, detail="At least one message is required")
+
+    last_msg = payload.messages[-1]
+    if last_msg.role != "user":
+        raise HTTPException(status_code=400, detail="Last message must be from user")
+
+    question = last_msg.content.strip()
+    if not question:
+        raise HTTPException(status_code=400, detail="Last message content must not be empty")
+
+    try:
+        get_metrics().record_query()
+
+        # Build conversation history for context (exclude current question)
+        history = [{"role": m.role, "content": m.content} for m in payload.messages[:-1]]
+
+        # Retrieve chunks for current question
+        chunks = qa_system.retrieve_relevant_chunks(
+            question,
+            top_k=payload.top_k,
+            similarity_threshold=payload.similarity_threshold,
+        )
+
+        if not chunks:
+            return ChatResponse(
+                answer="I couldn't find relevant information to answer your question.",
+                sources=[],
+                confidence="low",
+                chunks_retrieved=0,
+                average_similarity=0.0,
+            )
+
+        # Generate answer with conversation history
+        answer = qa_system.generate_answer(question, chunks, conversation_history=history if history else None)
+
+        sources = [
+            {
+                "document_name": c["document_name"],
+                "page_number": c.get("page_number", "unknown"),
+                "similarity_score": c["similarity_score"],
+                "text_preview": (c["text"][:200] + "...") if len(c["text"]) > 200 else c["text"],
+            }
+            for c in chunks
+        ]
+
+        avg_sim = sum(c["similarity_score"] for c in chunks) / len(chunks)
+        confidence = "high" if avg_sim > 0.8 else "medium" if avg_sim > 0.6 else "low"
+
+        return ChatResponse(
+            answer=answer.strip(),
+            sources=sources,
+            confidence=confidence,
+            chunks_retrieved=len(chunks),
+            average_similarity=avg_sim,
+        )
+
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        logger.error("Chat failed", question=question, error=str(e))
+        raise HTTPException(status_code=500, detail=f"Error during chat: {str(e)}") from e

--- a/src/backend/rag_pipeline/api/exception_handlers.py
+++ b/src/backend/rag_pipeline/api/exception_handlers.py
@@ -1,0 +1,47 @@
+"""RFC 7807 Problem Details exception handlers for the RAG API.
+
+Converts HTTPException and validation errors to application/problem+json format.
+"""
+
+from __future__ import annotations
+
+from fastapi import Request, status
+from fastapi.exceptions import HTTPException, RequestValidationError
+from fastapi.responses import JSONResponse
+
+PROBLEM_JSON = "application/problem+json"
+
+
+async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    """Convert HTTPException to RFC 7807 Problem Details format."""
+    content = {
+        "type": "about:blank",
+        "title": exc.detail if isinstance(exc.detail, str) else "HTTP Error",
+        "status": exc.status_code,
+        "detail": exc.detail,
+        "instance": str(request.url.path),
+    }
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=content,
+        media_type=PROBLEM_JSON,
+    )
+
+
+async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+    """Convert RequestValidationError to RFC 7807 Problem Details format."""
+    errors = exc.errors()
+    detail = errors[0].get("msg", "Validation error") if errors else "Validation error"
+    content = {
+        "type": "about:blank",
+        "title": "Validation Error",
+        "status": status.HTTP_422_UNPROCESSABLE_ENTITY,
+        "detail": detail,
+        "instance": str(request.url.path),
+        "errors": errors,
+    }
+    return JSONResponse(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        content=content,
+        media_type=PROBLEM_JSON,
+    )

--- a/src/backend/rag_pipeline/api/metrics.py
+++ b/src/backend/rag_pipeline/api/metrics.py
@@ -1,0 +1,81 @@
+"""Metrics API endpoint for the RAG pipeline.
+
+Exposes ingestion stats, query counts, and index size for observability.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+from fastapi import APIRouter
+
+from ..core.vector_store import get_vector_store_manager_from_env
+from ..utils.logging import StructuredLogger
+
+logger = StructuredLogger(__name__)
+
+router = APIRouter(tags=["metrics"])
+
+
+@dataclass
+class PipelineMetrics:
+    """In-memory metrics for the RAG pipeline."""
+
+    documents_ingested: int = 0
+    queries_total: int = 0
+    _last_ingestion_timestamp_ms: float = 0
+
+    def record_ingestion(self) -> None:
+        """Record a completed document ingestion."""
+        self.documents_ingested += 1
+        self._last_ingestion_timestamp_ms = time.time() * 1000
+
+    def record_query(self) -> None:
+        """Record a query."""
+        self.queries_total += 1
+
+    @property
+    def last_ingestion_timestamp_ms(self) -> float:
+        """Timestamp of last ingestion (ms since epoch)."""
+        return self._last_ingestion_timestamp_ms
+
+
+# Module-level singleton
+_metrics = PipelineMetrics()
+
+
+def get_metrics() -> PipelineMetrics:
+    """Return the shared metrics instance."""
+    return _metrics
+
+
+def _get_index_chunk_count() -> int:
+    """Get approximate chunk count from vector store (best effort)."""
+    try:
+        vsm = get_vector_store_manager_from_env()
+        # ChromaVectorStoreManager exposes _collection
+        coll = getattr(vsm, "_collection", None)
+        if coll is not None:
+            result = coll.get(include=[])
+            return len(result["ids"]) if result.get("ids") else 0
+    except Exception as e:
+        logger.warning("Could not get index chunk count", error=str(e))
+    return 0
+
+
+@router.get("/metrics")
+async def get_pipeline_metrics() -> dict:
+    """Return pipeline metrics for observability.
+
+    Returns:
+        JSON with documents_ingested, queries_total, index_chunks, last_ingestion_timestamp_ms.
+    """
+    m = get_metrics()
+    index_chunks = _get_index_chunk_count()
+    return {
+        "documents_ingested": m.documents_ingested,
+        "queries_total": m.queries_total,
+        "index_chunks": index_chunks,
+        "last_ingestion_timestamp_ms": m.last_ingestion_timestamp_ms,
+    }

--- a/src/backend/rag_pipeline/api/middleware/__init__.py
+++ b/src/backend/rag_pipeline/api/middleware/__init__.py
@@ -1,0 +1,5 @@
+"""FastAPI middleware for the RAG pipeline."""
+
+from .correlation_id import CorrelationIdMiddleware
+
+__all__ = ["CorrelationIdMiddleware"]

--- a/src/backend/rag_pipeline/api/middleware/correlation_id.py
+++ b/src/backend/rag_pipeline/api/middleware/correlation_id.py
@@ -1,0 +1,30 @@
+"""Correlation ID middleware for request tracing.
+
+Adds X-Correlation-ID header to requests and responses for distributed tracing.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Callable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+class CorrelationIdMiddleware(BaseHTTPMiddleware):
+    """Middleware that adds a correlation ID to each request and response.
+
+    Reads X-Correlation-ID from request if present, otherwise generates a new UUID.
+    Adds the same ID to the response for traceability.
+    """
+
+    HEADER_NAME = "X-Correlation-ID"
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        """Process request and add correlation ID to response."""
+        correlation_id = request.headers.get(self.HEADER_NAME) or str(uuid.uuid4())
+        response = await call_next(request)
+        response.headers[self.HEADER_NAME] = correlation_id
+        return response

--- a/src/backend/rag_pipeline/api/middleware/rate_limit.py
+++ b/src/backend/rag_pipeline/api/middleware/rate_limit.py
@@ -1,0 +1,86 @@
+"""Rate limiting middleware for the RAG API.
+
+Simple in-memory rate limiter: configurable requests per minute per client IP.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from typing import Callable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+# Paths excluded from rate limiting
+BYPASS_PATHS = {
+    "/health",
+    "/healthz",
+    "/ready",
+    "/api/health",
+    "/metrics",
+    "/docs",
+    "/redoc",
+    "/openapi.json",
+    "/favicon.ico",
+}
+
+# Default: 60 requests per minute per IP
+DEFAULT_RPM = 60
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Middleware that limits requests per minute per client IP."""
+
+    def __init__(
+        self,
+        app,
+        requests_per_minute: int = DEFAULT_RPM,
+        bypass_paths: set[str] | None = None,
+    ):
+        super().__init__(app)
+        self.rpm = requests_per_minute
+        self.bypass = bypass_paths if bypass_paths is not None else BYPASS_PATHS
+        # IP -> list of timestamps (last N requests)
+        self._requests: dict[str, list[float]] = defaultdict(list)
+
+    def _should_bypass(self, path: str) -> bool:
+        """Check if path should bypass rate limiting."""
+        return any(path == p or path.startswith(p + "/") for p in self.bypass)
+
+    def _is_rate_limited(self, client_ip: str) -> bool:
+        """Check if client has exceeded rate limit."""
+        now = time.time()
+        window_start = now - 60  # 1 minute window
+        # Prune old timestamps
+        self._requests[client_ip] = [t for t in self._requests[client_ip] if t > window_start]
+        return len(self._requests[client_ip]) >= self.rpm
+
+    def _record_request(self, client_ip: str) -> None:
+        """Record a request for the client."""
+        self._requests[client_ip].append(time.time())
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        """Process request and enforce rate limit."""
+        path = request.url.path
+        if self._should_bypass(path):
+            return await call_next(request)
+
+        client_ip = request.client.host if request.client else "unknown"
+        if self._is_rate_limited(client_ip):
+            return JSONResponse(
+                status_code=429,
+                content={
+                    "type": "about:blank",
+                    "title": "Too Many Requests",
+                    "status": 429,
+                    "detail": f"Rate limit exceeded. Maximum {self.rpm} requests per minute.",
+                    "instance": path,
+                },
+                media_type="application/problem+json",
+                headers={"Retry-After": "60"},
+            )
+
+        self._record_request(client_ip)
+        return await call_next(request)

--- a/src/backend/rag_pipeline/api/query.py
+++ b/src/backend/rag_pipeline/api/query.py
@@ -12,6 +12,7 @@ from ..core.embeddings import query_embeddings
 from ..core.vector_store import get_vector_store_manager_from_env
 from ..main import process_medical_conversation
 from ..utils.logging import StructuredLogger
+from .metrics import get_metrics
 
 logger = StructuredLogger(__name__)
 router = APIRouter(prefix="/api/query", tags=["query"])
@@ -66,6 +67,7 @@ async def query_documents(payload: QueryRequest) -> dict:
     top_k = payload.top_k if payload.top_k is not None else params.retrieval.top_k
 
     try:
+        get_metrics().record_query()
         results = query_embeddings(
             payload.query,
             params.embedding.model_name,

--- a/tests/test_enhanced_documents_api.py
+++ b/tests/test_enhanced_documents_api.py
@@ -197,8 +197,12 @@ class TestEnhancedDocumentsAPI:
         assert response.status_code == 422  # FastAPI returns 422 for validation errors
         data = response.json()
         assert "detail" in data
-        # Check that the error is about missing files
-        assert any("files" in str(error).lower() for error in data["detail"])
+        # RFC 7807: errors list holds validation details; detail is first error message
+        errors = data.get("errors", data.get("detail", []))
+        if isinstance(errors, list):
+            assert any("files" in str(error).lower() for error in errors)
+        else:
+            assert "files" in str(errors).lower()
 
     def test_upload_too_many_files(self, client):
         """Test uploading too many files.

--- a/tests/test_query_routes.py
+++ b/tests/test_query_routes.py
@@ -23,4 +23,6 @@ def test_process_conversation_endpoint_empty_text():
     """Test the /api/query/process_conversation endpoint with empty text."""
     response = client.post("/api/query/process_conversation", json={"text": ""})
     assert response.status_code == 400
-    assert response.json() == {"detail": "Text must not be empty"}
+    data = response.json()
+    assert data.get("detail") == "Text must not be empty"
+    assert data.get("status") == 400

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -17,6 +17,30 @@ def test_health_endpoint() -> None:
     assert resp.json() == {"status": "ok"}
 
 
+def test_correlation_id_in_response() -> None:
+    """As a user I want correlation IDs in responses for tracing.
+    Technical: All responses include X-Correlation-ID header.
+    """
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    assert "X-Correlation-ID" in resp.headers
+
+
+def test_metrics_endpoint() -> None:
+    """As a user I want metrics for observability, so I can monitor pipeline usage.
+    Technical: GET /metrics returns documents_ingested, queries_total, index_chunks.
+    """
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "documents_ingested" in data
+    assert "queries_total" in data
+    assert "index_chunks" in data
+    assert "last_ingestion_timestamp_ms" in data
+    assert isinstance(data["documents_ingested"], int)
+    assert isinstance(data["queries_total"], int)
+
+
 def test_documents_list(tmp_path, monkeypatch) -> None:
     """Test the document listing endpoint."""
     file_path = tmp_path / "example.txt"
@@ -25,3 +49,101 @@ def test_documents_list(tmp_path, monkeypatch) -> None:
     resp = client.get("/api/documents/list")
     assert resp.status_code == 200
     assert resp.json()["files"] == ["example.txt"]
+
+
+def test_documents_delete_success(tmp_path, monkeypatch) -> None:
+    """As a user I want to delete uploaded documents, so I can free storage and remove sensitive data.
+    Technical: DELETE /api/documents/{filename} removes file and vector chunks.
+    Validation: 204 on success, file gone from list.
+    """
+    monkeypatch.setattr("src.backend.rag_pipeline.api.documents.uploaded_files_dir", tmp_path)
+    file_path = tmp_path / "to_delete.txt"
+    file_path.write_text("content")
+    mock_vsm = type("MockVSM", (), {"delete_by_document_name": lambda self, n: 3})()
+    monkeypatch.setattr("src.backend.rag_pipeline.api.documents.vector_store_manager", mock_vsm)
+
+    resp = client.delete("/api/documents/to_delete.txt")
+    assert resp.status_code == 204
+    assert not file_path.exists()
+    list_resp = client.get("/api/documents/list")
+    assert "to_delete.txt" not in list_resp.json()["files"]
+
+
+def test_documents_delete_not_found(tmp_path, monkeypatch) -> None:
+    """As a user I want clear feedback when deleting non-existent documents.
+    Technical: DELETE returns 404 when document does not exist.
+    """
+    monkeypatch.setattr("src.backend.rag_pipeline.api.documents.uploaded_files_dir", tmp_path)
+    resp = client.delete("/api/documents/nonexistent.pdf")
+    assert resp.status_code == 404
+    assert "not found" in resp.json()["detail"].lower()
+
+
+def test_error_responses_follow_rfc7807(tmp_path, monkeypatch) -> None:
+    """As a user I want structured error responses, so I can handle failures programmatically.
+    Technical: HTTPException and validation errors return application/problem+json.
+    """
+    monkeypatch.setattr("src.backend.rag_pipeline.api.documents.uploaded_files_dir", tmp_path)
+    resp = client.delete("/api/documents/nonexistent.pdf")
+    assert resp.status_code == 404
+    assert resp.headers.get("content-type", "").startswith("application/problem+json")
+    data = resp.json()
+    assert "type" in data
+    assert "title" in data
+    assert data["status"] == 404
+    assert "detail" in data
+    assert "instance" in data
+
+
+def test_chat_endpoint_accepts_messages(monkeypatch) -> None:
+    """As a user I want a chat endpoint with message history, so I can have multi-turn conversations.
+    Technical: POST /api/chat accepts messages list and returns answer with sources.
+    Validation: Mock QA system; verify request/response contract.
+    """
+    mock_chunks = [{"text": "Test content", "document_name": "doc.pdf", "page_number": 1, "similarity_score": 0.9}]
+
+    def mock_retrieve(*args, **kwargs):
+        return mock_chunks
+
+    def mock_generate(question, chunks, conversation_history=None):
+        return "Mocked answer"
+
+    monkeypatch.setattr("src.backend.rag_pipeline.api.chat.qa_system.retrieve_relevant_chunks", mock_retrieve)
+    monkeypatch.setattr("src.backend.rag_pipeline.api.chat.qa_system.generate_answer", mock_generate)
+
+    resp = client.post(
+        "/api/chat",
+        json={
+            "messages": [
+                {"role": "user", "content": "First question"},
+                {"role": "assistant", "content": "First answer"},
+                {"role": "user", "content": "Follow-up question"},
+            ],
+            "top_k": 5,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["answer"] == "Mocked answer"
+    assert len(data["sources"]) == 1
+    assert data["sources"][0]["document_name"] == "doc.pdf"
+
+
+def test_chat_requires_last_message_from_user() -> None:
+    """As a user I want validation that last message is from user.
+    Technical: POST /api/chat returns 400 if last message is not from user.
+    """
+    resp = client.post(
+        "/api/chat",
+        json={"messages": [{"role": "assistant", "content": "Previous answer"}]},
+    )
+    assert resp.status_code == 400
+
+
+def test_documents_delete_rejects_invalid_filename(tmp_path, monkeypatch) -> None:
+    """As a user I want the API to reject invalid filenames with .. in the name.
+    Technical: Filenames with .. return 400 for path traversal prevention.
+    """
+    monkeypatch.setattr("src.backend.rag_pipeline.api.documents.uploaded_files_dir", tmp_path)
+    resp = client.delete("/api/documents/bad..name.pdf")  # contains ..
+    assert resp.status_code == 400


### PR DESCRIPTION
Closes #80

## Summary
Implements remaining FastAPI REST API items from issue #80:

- **DELETE /api/documents/{filename}** — Remove document and its vector store chunks (with path traversal protection)
- **POST /api/chat** — Conversational RAG with message history for multi-turn context
- **GET /metrics** — Pipeline observability: documents_ingested, queries_total, index_chunks
- **RFC 7807 Problem Details** — application/problem+json for HTTPException and validation errors
- **Rate limiting** — 120 req/min per IP; bypass for /health, /metrics, /docs
- **Correlation ID middleware** — X-Correlation-ID on all responses

## Tests
- 622 passed
- New tests for DELETE, metrics, correlation ID, RFC 7807, chat endpoint
- Updated test_enhanced_documents_api and test_query_routes for RFC 7807 response format
