### PR TITLE
chore: Chroma vector store abstraction and DI cleanup

### DIFF
--- a/docs/technical/VECTOR_STORE.md
+++ b/docs/technical/VECTOR_STORE.md
@@ -51,6 +51,16 @@ The vector store is crucial for:
 
 ## Implementation Details
 
+### VectorStoreManager Abstraction
+
+The RAG pipeline uses a `VectorStoreManager` ABC to decouple consumers from ChromaDB. Chroma is the default implementation (`ChromaVectorStoreManager`). Metrics, BM25, and retrieval use the abstract interface:
+
+- `get_chunk_count()` — for metrics and observability
+- `get_all_chunks(limit)` — for BM25 sparse indexing
+- `get_storage_context()`, `add_embeddings()`, `query()`, `delete_by_document_name()`
+
+Use `get_vector_store_manager()` (no args = from env) to obtain a manager. Inject `VectorStoreManager` into services for testability and swappability.
+
 ### ChromaDB Setup
 
 ```python

--- a/scripts/upload_documents.py
+++ b/scripts/upload_documents.py
@@ -22,7 +22,7 @@ import httpx
 from backend.rag_pipeline.config.parameter_sets import get_param_set
 from backend.rag_pipeline.core.embeddings import process_document
 from backend.rag_pipeline.core.vector_store import (
-    get_vector_store_manager_from_env,
+    get_vector_store_manager,
 )
 from backend.shared.utils.directory_utils import (
     ensure_directory_exists,
@@ -147,7 +147,7 @@ def upload_file(path: Path, upload_name: str, api_url: str, params_name: str) ->
             raise UploadError(f"{path}: {resp.status_code} {resp.text}")
 
 
-vector_store_manager = get_vector_store_manager_from_env()
+vector_store_manager = get_vector_store_manager()
 
 
 def clear_backend() -> None:

--- a/src/backend/rag_pipeline/api/documents.py
+++ b/src/backend/rag_pipeline/api/documents.py
@@ -22,7 +22,7 @@ from backend.shared.utils.directory_utils import (
 
 from ..config.parameter_sets import DEFAULT_PARAM_SET_NAME, RAGParams, get_param_set
 from ..core.document_loader import DocumentLoader
-from ..core.vector_store import get_vector_store_manager_from_env
+from ..core.vector_store import get_vector_store_manager
 from ..services.document_processing_service import DocumentProcessingService
 from ..utils.docx_utils import extract_and_clean_docx
 from ..utils.logging import StructuredLogger
@@ -38,7 +38,7 @@ router = APIRouter(prefix="/api/documents", tags=["documents"])
 uploaded_files_dir = get_uploaded_files_dir()
 ensure_directory_exists(uploaded_files_dir)
 document_loader = DocumentLoader()
-vector_store_manager = get_vector_store_manager_from_env()
+vector_store_manager = get_vector_store_manager()
 document_processing_service = DocumentProcessingService()
 
 

--- a/src/backend/rag_pipeline/api/health.py
+++ b/src/backend/rag_pipeline/api/health.py
@@ -4,7 +4,7 @@ from starlette.responses import JSONResponse
 
 from ..config.llm_config import get_llm_config
 from ..core.llm_providers import get_llm_provider_from_env
-from ..core.vector_store import get_vector_store_manager_from_env
+from ..core.vector_store import get_vector_store_manager
 
 router = APIRouter()
 
@@ -28,7 +28,7 @@ async def health_database():
     # which doesn't require a separate database connection
     try:
         # Try to access the vector store to verify it's working
-        get_vector_store_manager_from_env()
+        get_vector_store_manager()
         # If we can create the vector store manager, the database is healthy
         return JSONResponse(content={"status": "ok"})
     except Exception as e:
@@ -59,7 +59,7 @@ async def health_vector_store():
     """Check the health of the vector store."""
     try:
         # Try to access the collection to verify it's working
-        get_vector_store_manager_from_env()
+        get_vector_store_manager()
         # This is a simple health check - we just verify we can create the manager
         return JSONResponse(content={"status": "ok"})
     except Exception as e:

--- a/src/backend/rag_pipeline/api/metrics.py
+++ b/src/backend/rag_pipeline/api/metrics.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 
 from fastapi import APIRouter
 
-from ..core.vector_store import get_vector_store_manager_from_env
+from ..core.vector_store import get_vector_store_manager
 from ..utils.logging import StructuredLogger
 
 logger = StructuredLogger(__name__)
@@ -53,12 +53,8 @@ def get_metrics() -> PipelineMetrics:
 def _get_index_chunk_count() -> int:
     """Get approximate chunk count from vector store (best effort)."""
     try:
-        vsm = get_vector_store_manager_from_env()
-        # ChromaVectorStoreManager exposes _collection
-        coll = getattr(vsm, "_collection", None)
-        if coll is not None:
-            result = coll.get(include=[])
-            return len(result["ids"]) if result.get("ids") else 0
+        vsm = get_vector_store_manager()
+        return vsm.get_chunk_count()
     except Exception as e:
         logger.warning("Could not get index chunk count", error=str(e))
     return 0

--- a/src/backend/rag_pipeline/core/qa_system.py
+++ b/src/backend/rag_pipeline/core/qa_system.py
@@ -15,7 +15,7 @@ from typing import Any
 from backend.rag_pipeline.config.parameter_sets import DEFAULT_PARAM_SET_NAME, get_param_set
 from backend.rag_pipeline.core.llm_providers import LLMProvider, get_llm_provider_from_env
 from backend.rag_pipeline.core.retrieval import create_retrieval_service
-from backend.rag_pipeline.core.vector_store import get_vector_store_manager_from_env
+from backend.rag_pipeline.core.vector_store import get_vector_store_manager
 
 from ..utils.logging import StructuredLogger
 
@@ -32,7 +32,7 @@ class QASystem:
             llm_provider: Optional LLM provider. If None, will use default Ollama provider.
         """
         self.llm_provider = llm_provider or self._create_default_llm_provider()
-        self.vector_store_manager = get_vector_store_manager_from_env()
+        self.vector_store_manager = get_vector_store_manager()
 
     def _create_default_llm_provider(self) -> LLMProvider:
         """Create LLM provider from LLM_BACKEND and LLM_MODEL env vars.

--- a/src/backend/rag_pipeline/core/rag_system.py
+++ b/src/backend/rag_pipeline/core/rag_system.py
@@ -38,7 +38,7 @@ from llama_index.readers.file import DocxReader, PDFReader
 
 # Local imports
 from backend.rag_pipeline.config.parameter_sets import RAGParams
-from backend.rag_pipeline.core.vector_store import VectorStoreManager, get_vector_store_manager_from_env
+from backend.rag_pipeline.core.vector_store import VectorStoreManager, get_vector_store_manager
 from backend.shared.utils.directory_utils import (
     DirectoryEmptyError,
     ensure_directory,
@@ -114,7 +114,7 @@ class LocalRAGSystem:
             description="embeddings cache directory",
         )
 
-        self.vector_store_manager = vector_store_manager or get_vector_store_manager_from_env()
+        self.vector_store_manager = vector_store_manager or get_vector_store_manager()
 
         # Initialize components and set global settings
         Settings.llm = self._setup_llm()

--- a/src/backend/rag_pipeline/evaluation/runner.py
+++ b/src/backend/rag_pipeline/evaluation/runner.py
@@ -106,9 +106,9 @@ def _default_retrieve_factory() -> Callable[[str], Callable[[str, int], list[dic
     def factory(config_name: str) -> Callable[[str, int], list[dict[str, Any]]]:
         from backend.rag_pipeline.config.parameter_sets import DEFAULT_PARAM_SET_NAME, get_param_set
         from backend.rag_pipeline.core.retrieval import create_retrieval_service
-        from backend.rag_pipeline.core.vector_store import get_vector_store_manager_from_env
+        from backend.rag_pipeline.core.vector_store import get_vector_store_manager
 
-        vsm = get_vector_store_manager_from_env()
+        vsm = get_vector_store_manager()
         params = get_param_set(DEFAULT_PARAM_SET_NAME)
         persist_dir = str(vsm.config.persist_directory)
         model_name = params.embedding.model_name

--- a/src/backend/rag_pipeline/services/document_processing_service.py
+++ b/src/backend/rag_pipeline/services/document_processing_service.py
@@ -15,7 +15,7 @@ from typing import Dict, List, Optional
 
 from ..config.parameter_sets import RAGParams, get_param_set
 from ..core.embeddings import process_document
-from ..core.vector_store import get_vector_store_manager_from_env
+from ..core.vector_store import get_vector_store_manager
 from ..models.document_models import DocumentMetadata
 from ..utils.logging import StructuredLogger
 from ..utils.progress import ProgressEvent, progress_notifier
@@ -31,7 +31,7 @@ class DocumentProcessingService:
 
     def __init__(self):
         """Initialize the document processing service."""
-        self.vector_store_manager = get_vector_store_manager_from_env()
+        self.vector_store_manager = get_vector_store_manager()
 
         logger.info("DocumentProcessingService initialized")
 

--- a/src/backend/rag_pipeline/services/query_service.py
+++ b/src/backend/rag_pipeline/services/query_service.py
@@ -1,7 +1,7 @@
 """Query service for semantic document search."""
 
 from ..core.embeddings import query_embeddings
-from ..core.vector_store import get_vector_store_manager_from_env
+from ..core.vector_store import get_vector_store_manager
 from ..utils.logging import StructuredLogger
 
 logger = StructuredLogger(__name__)
@@ -15,7 +15,7 @@ class QueryService:
     """
 
     def __init__(self):
-        self.vector_store_manager = get_vector_store_manager_from_env()
+        self.vector_store_manager = get_vector_store_manager()
 
     def query(self, query_text: str, model_name: str, top_k: int) -> dict:
         """Run a semantic search against the vector store.

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -41,3 +41,31 @@ class TestChromaVectorStoreManager:
         import gc
 
         gc.collect()
+
+    def test_get_chunk_count_and_get_all_chunks(self, test_case_dir):
+        """As a user I want metrics and BM25 to use the abstract interface.
+        Technical: get_chunk_count and get_all_chunks work via ABC.
+        """
+        config = VectorStoreConfig(
+            host=None, persist_directory=str(test_case_dir), collection_name="test_chunks_abc"
+        )
+        manager = ChromaVectorStoreManager(config)
+
+        manager.add_embeddings(
+            ids=["c1", "c2"],
+            embeddings=[[0.1, 0.2], [0.3, 0.4]],
+            metadatas=[{"text": "hello world", "chunk_index": 0}, {"text": "foo bar", "chunk_index": 1}],
+        )
+
+        assert manager.get_chunk_count() == 2
+
+        ids, texts, metadatas = manager.get_all_chunks(limit=100)
+        assert ids == ["c1", "c2"]
+        assert texts == ["hello world", "foo bar"]
+        assert len(metadatas) == 2
+        assert metadatas[0].get("chunk_index") == 0
+
+        del manager
+        import gc
+
+        gc.collect()


### PR DESCRIPTION
- Add get_chunk_count() and get_all_chunks() to VectorStoreManager ABC
- Fix metrics.py leaky abstraction (use get_chunk_count instead of _collection)
- Refactor BM25Store to depend on VectorStoreManager via get_all_chunks()
- Remove redundant get_vector_store_manager_from_env, use get_vector_store_manager()
- Add test for new ABC methods
- Document abstraction in VECTOR_STORE.md