### PR TITLE
chore: unify skills, tmp/ layout, and workflow docs

### DIFF
--- a/.claude/skills/create-validation/SKILL.md
+++ b/.claude/skills/create-validation/SKILL.md
@@ -9,32 +9,8 @@ argument-hint: [#issue-number or feature-slug]
 Create a validation document for $ARGUMENTS.
 
 Parse $ARGUMENTS:
-- `#NNN` or `NNN` → issue number; load from `tmp/github/issue-descriptions/issue-NNN.md` or run `gh issue view NNN`
+- `#NNN` or `NNN` → issue number; load from `tmp/github/issue-NNN/description.md` or run `gh issue view NNN`
 - `for <slug>` → feature slug; save as `docs/validations/feature-<slug>-validation.md`
 - *(empty)* → ask user for issue number or feature name
 
 Follow [.cursor/skills/create-validation/SKILL.md](../../../.cursor/skills/create-validation/SKILL.md) exactly.
-
-## Quick Reference
-
-**Goal**: Produce a `tmp/validations/issue-NNN-validation.md` (or `docs/validations/feature-<slug>-validation.md`) where every step has:
-- An exact **Action** (command or UI instruction)
-- An explicit **Expected** outcome (no vague wording)
-- A `- [ ] Step passed` checkbox
-
-**Format spec**: [docs/technical/VALIDATION_FORMAT.md](../../../docs/technical/VALIDATION_FORMAT.md)
-
-**Step types**: CLI command · HTTP request · UI browser check · file check · log check
-
-**Quality bar**: A person who didn't write the code can execute the validation and reach the same conclusion.
-
-## After Creating
-
-Report:
-```
-Created: tmp/validations/issue-NNN-validation.md
-Steps: N steps (prerequisites: X | tests: Y | API: Z | UI: W)
-Run: /run-validation #NNN
-```
-
-Update `tmp/github/progress/issue-NNN-workflow.md` to reference the validation file.

--- a/.claude/skills/run-validation/SKILL.md
+++ b/.claude/skills/run-validation/SKILL.md
@@ -9,48 +9,8 @@ argument-hint: [#issue-number or path/to/validation.md]
 Execute the validation for $ARGUMENTS.
 
 Parse $ARGUMENTS:
-- `#NNN` or `NNN` → load `tmp/validations/issue-NNN-validation.md`
+- `#NNN` or `NNN` → load `tmp/github/issue-NNN/validation.md`
 - file path → load from that path
-- *(empty)* → list `tmp/validations/*.md` and ask user to select
+- *(empty)* → list `tmp/github/issue-*/validation.md` and ask user to select
 
 Follow [.cursor/skills/run-validation/SKILL.md](../../../.cursor/skills/run-validation/SKILL.md) exactly.
-
-## Quick Reference
-
-**Protocol** (per step, in order):
-1. Execute the action (run command / navigate URL / read file)
-2. Compare actual output to Expected
-3. **PASS** → mark `[x]`, report "✓ Step N passed"
-4. **FAIL** → diagnose root cause → fix code or correct validation → re-run
-5. If still failing → mark `[!]` blocked, document blocker, continue
-
-**On correction**: Rewrite the step's Action or Expected in the file. Add inline note:
-> **Correction (YYYY-MM-DD):** [what changed and why]
-
-Never silently change expectations to pass a failing step.
-
-**Blocking failure**: If a prerequisite step fails and all subsequent steps depend on it, stop and report.
-
-## Final Report Format
-
-```
-Validation: <title>
-Result: PASSED / FAILED
-Steps: N passed, M failed, K blocked
-
-Failed:
-- Step X: [title] — [reason]
-
-Next steps: [fix suggestion or /commit if passed]
-```
-
-## Post-Pass Actions
-
-1. Update `status: passed` in frontmatter
-2. Check `- [ ] All steps passed` in "Overall Validation Result"
-3. Suggest:
-   ```bash
-   gh issue comment NNN --body "Validation passed. All N steps verified."
-   ```
-4. Update acceptance criteria checkboxes in the GitHub issue body
-5. Update `tmp/github/progress/issue-NNN-workflow.md` with validation outcome

--- a/.cursor/commands/README.md
+++ b/.cursor/commands/README.md
@@ -2,34 +2,94 @@
 
 Commands are invoked with `/command-name`. Use **delegation** for reuse; keep the flow **acyclic**.
 
-## Workflow Flow (acyclic)
+## Issue Workflow
+
+Working on a GitHub issue follows this lifecycle:
 
 ```
-/get-started  →  /create-validation  →  (work)  →  /run-validation  →  /commit  →  /pr  →  /branch-cleanup
-   ↓                   ↓                                  ↓                ↓           ↑
-   entry for issues    define how to verify          verify + fix     gate on pass  prereqs done
+Phase 1: Analyse
+  - Is the issue still valid? Already implemented?
+  - Search codebase, git log, merged PRs for duplicates
+  - Identify 2-3 solution directions; pick the best one
+  - Refine acceptance criteria and fill missing detail
+  - Post refinement comment to GitHub issue
+
+Phase 2: Plan
+  - Create branch from base
+  - Break down into tasks; decide test strategy
+  - Define how implementation will be validated
+  - Post plan comment to GitHub issue
+
+Phase 3: Implement
+  - Work in small increments; commit after each
+  - Run tests after each logical change
+  - Keep tmp/github/issue-NNN/workflow.md updated so sessions can resume
+
+Phase 4: Validate
+  - Run /create-validation to define verification steps (can be done in Phase 2 for TDD)
+  - Run /run-validation to execute; fix failures; gate PR on pass
+
+Phase 5: PR and merge
+  - /commit → /pr (base: correct branch; title references issue)
+  - Merge after review; /branch-cleanup
 ```
 
-- **get-started**: Entry for issue work. Suggests `/create-validation`, `/commit`, `/pr` as next steps.
-- **create-validation**: After planning — define verification steps before or during implementation.
-- **run-validation**: After implementation — execute validation, fix failures, gate PR on pass.
-- **commit**: Create commits. Suggests `/pr` when ready.
-- **pr**: Create PR. Prerequisites: all changes committed; validation passed.
-- **branch-cleanup**: After PR is merged. Sync main, prune refs, delete merged/gone local branches.
+### Commands per Phase
+
+```
+/get-started  ──────────────────────────────────────────────────────────────────────┐
+   Phase 1: Analyse (validate issue, find duplicates, refine)                       │
+   Phase 2: Plan (branch, break down, test strategy)                                │
+   Phase 3: Implement (incremental commits, tests, session continuity)              │
+        │                                                                            │
+        ├── /create-validation  (Phase 2 or 3 — define verification steps)          │
+        │         │                                                                  │
+        │         └── /run-validation  (Phase 4 — execute, fix, report pass/fail)   │
+        │                   │                                                        │
+        └───────────────────┴── /commit ── /pr ── /branch-cleanup ──────────────────┘
+```
+
+### Issue-Validation vs Implementation-Validation
+
+Two distinct validation activities exist — do not conflate them:
+
+| | **Issue validation** (Phase 1) | **Implementation validation** (Phase 4) |
+|---|---|---|
+| **Purpose** | Is this issue worth doing? | Is the implementation correct? |
+| **When** | Before writing any code | After implementation (or TDD: before) |
+| **Output** | Decision: proceed / close / redirect | Pass/fail validation document |
+| **Tool** | `/get-started` Phase 1 analysis | `/create-validation` + `/run-validation` |
+| **Stored in** | `tmp/github/issue-NNN/workflow.md` | `tmp/github/issue-NNN/validation.md` |
+
+`/create-validation` can be run in Phase 2 (before implementation) to define acceptance criteria as executable steps — this is the TDD approach. Or it can be run in Phase 4 after implementation to codify what was built. Both are valid.
 
 ## Commands
 
 | Command | Purpose | Next / Uses |
 |---------|---------|-------------|
-| `/get-started` | Issue workflow (Validate → Plan → Implement) | `/create-validation`, `/commit`, `/pr` when ready |
-| `/create-validation` | Create step-by-step validation document for a feature/issue | `/run-validation` after implementation |
-| `/run-validation` | Execute validation, check/fix steps, report pass/fail | `/commit` when passed; fix when failed |
-| `/commit` | Create commits with quality checks | `/pr` when ready; [commit-message-standards](.cursor/rules/commit-message-standards.mdc) |
+| `/get-started` | Full issue lifecycle: Analyse → Plan → Implement | `/create-validation`, `/commit`, `/pr` |
+| `/create-validation` | Create executable validation document for issue or feature | `/run-validation` |
+| `/run-validation` | Execute validation step-by-step, fix failures, gate on pass | `/commit` when passed |
+| `/commit` | Create commits with quality checks | `/pr` when ready |
 | `/pr` | Create pull request | Prereq: commits done; validation passed |
-| `/branch-cleanup` | Sync local branches after PR merged (main, prune, delete merged/gone) | After `/pr` merge; merge/squash/rebase |
-| `/test` | Run tests with service management | Used by commit (require tests), pr (pre-flight) |
+| `/branch-cleanup` | Sync local branches after PR merged (main, prune, delete merged/gone) | After `/pr` merge |
+| `/test` | Run tests with service management | Used by commit, pr |
 | `/update-commits` | WBSO: refresh commit CSVs from `repositories.csv` | Standalone |
-| `/update-date-tags` | Update Created/Updated tags in files | [date-formatting](.cursor/rules/date-formatting.mdc) |
+| `/update-date-tags` | Update Created/Updated tags in files | Standalone |
+
+## Scratch Files
+
+All issue scratch files live under `tmp/github/issue-NNN/`:
+
+| File | Purpose |
+|------|---------|
+| `description.md` | Cached issue body (`gh issue view NNN`) |
+| `workflow.md` | Phase tracking, decisions, validation outcomes, next steps |
+| `plan.md` | Implementation plan (Phase 2) |
+| `validation.md` | Validation document (created by `/create-validation`) |
+| `comments/` | Draft comments before posting (refinement, plan, milestone, close) |
+
+See `tmp/CLAUDE.md` for the full scratch directory rules.
 
 ## Rules
 
@@ -40,4 +100,4 @@ Commands are invoked with `/command-name`. Use **delegation** for reuse; keep th
 ## Validation Format
 
 - [docs/technical/VALIDATION_FORMAT.md](../../docs/technical/VALIDATION_FORMAT.md) — schema for validation files created by `/create-validation` and consumed by `/run-validation`
-- Storage: `tmp/validations/issue-NNN-validation.md` (session-scoped) or `docs/validations/feature-<slug>-validation.md` (committed)
+- Storage: `tmp/github/issue-NNN/validation.md` (issue-scoped) or `docs/validations/feature-<slug>-validation.md` (committed)

--- a/.cursor/commands/create-validation.md
+++ b/.cursor/commands/create-validation.md
@@ -22,14 +22,16 @@ The user may append text after `/create-validation`. Parse:
 
 | Pattern | Extracted | Example |
 |---------|-----------|---------|
-| `#NNN` or `issue NNN` | Issue number → load from `tmp/github/issue-descriptions/issue-NNN.md` | `/create-validation #82` |
+| `#NNN` or `issue NNN` | Issue number → load from `tmp/github/issue-NNN/description.md` | `/create-validation #82` |
 | `for <feature>` | Feature slug → save as `docs/validations/feature-<slug>-validation.md` | `/create-validation for document-upload` |
 | *(empty)* | Interactive — ask for issue number or feature name | `/create-validation` |
 
 ## Storage
 
-- Default: `tmp/validations/issue-NNN-validation.md` (gitignored, session-scoped)
+- Default: `tmp/github/issue-NNN/validation.md` (gitignored, issue-scoped)
 - Use `docs/validations/` only when explicitly requested by user (committed, permanent)
+
+All issue scratch files live together under `tmp/github/issue-NNN/` — see `tmp/CLAUDE.md`.
 
 ## Execution
 
@@ -40,13 +42,13 @@ Follow [.cursor/skills/create-validation/SKILL.md](../skills/create-validation/S
 2. Map each acceptance criterion to verifiable steps (test, API, UI, file, log)
 3. Write steps with exact commands and explicit expected outcomes
 4. Write prerequisites
-5. Save to `tmp/validations/issue-NNN-validation.md`
-6. Update `tmp/github/progress/issue-NNN-workflow.md` to reference the validation
+5. Save to `tmp/github/issue-NNN/validation.md`
+6. Update `tmp/github/issue-NNN/workflow.md` to reference the validation
 
 ## Output
 
 ```
-Created: tmp/validations/issue-NNN-validation.md
+Created: tmp/github/issue-NNN/validation.md
 Steps: N (prerequisites + X test + Y API + Z UI)
 Run with: /run-validation #NNN
 ```

--- a/.cursor/commands/run-validation.md
+++ b/.cursor/commands/run-validation.md
@@ -20,9 +20,9 @@ Execute a validation document step by step. For each step: run the command or ch
 
 | Pattern | Action |
 |---------|--------|
-| `#NNN` or `issue NNN` | Load `tmp/validations/issue-NNN-validation.md` |
+| `#NNN` or `issue NNN` | Load `tmp/github/issue-NNN/validation.md` |
 | File path | Load validation from that path |
-| *(empty)* | List `tmp/validations/*.md`, ask user to select |
+| *(empty)* | List `tmp/github/issue-*/validation.md`, ask user to select |
 
 ## Execution
 

--- a/.cursor/skills/create-validation/SKILL.md
+++ b/.cursor/skills/create-validation/SKILL.md
@@ -21,18 +21,20 @@ See [docs/technical/VALIDATION_FORMAT.md](../../docs/technical/VALIDATION_FORMAT
 
 | Scope | Location |
 |-------|----------|
-| Session-scoped (ephemeral) | `tmp/validations/issue-NNN-validation.md` |
+| Issue-scoped (ephemeral) | `tmp/github/issue-NNN/validation.md` |
 | Feature-scoped (committed) | `docs/validations/feature-<slug>-validation.md` |
 
-Default to `tmp/validations/` unless the user asks for a committed validation.
+Default to `tmp/github/issue-NNN/` unless the user asks for a committed validation.
+
+All issue scratch files live under `tmp/github/issue-NNN/` — see `tmp/CLAUDE.md` for the full layout.
 
 ## How to Create a Validation
 
 ### 1. Gather Context
 
 Read:
-- The issue acceptance criteria (`gh issue view NNN` or `tmp/github/issue-descriptions/issue-NNN.md`)
-- The implementation plan (`tmp/github/progress/issue-NNN-plan.md`)
+- The issue acceptance criteria (`gh issue view NNN` or `tmp/github/issue-NNN/description.md`)
+- The implementation plan (`tmp/github/issue-NNN/plan.md`)
 - Relevant API docs, service ports (`docs/PORTS.md`), and entry point commands (CLAUDE.md)
 
 ### 2. Identify Validation Steps
@@ -66,9 +68,9 @@ One sentence: "This validation asserts that [feature] is implemented correctly b
 
 ### 6. Save the File
 
-Write to `tmp/validations/issue-NNN-validation.md` using the format template in VALIDATION_FORMAT.md.
+Write to `tmp/github/issue-NNN/validation.md` using the format template in VALIDATION_FORMAT.md.
 
-Update `tmp/github/progress/issue-NNN-workflow.md` to reference the validation file.
+Update `tmp/github/issue-NNN/workflow.md` to reference the validation file and record the issue number or chore slug it was created for.
 
 ## Quality Bar for Validations
 

--- a/.cursor/skills/run-validation/SKILL.md
+++ b/.cursor/skills/run-validation/SKILL.md
@@ -16,9 +16,9 @@ Reads a validation file, executes each step, tracks pass/fail, and iterates on f
 ## Inputs
 
 The user provides one of:
-- An issue number (`#NNN`) → look for `tmp/validations/issue-NNN-validation.md`
+- An issue number (`#NNN`) → look for `tmp/github/issue-NNN/validation.md`
 - A file path → read validation from that path
-- Nothing → list `tmp/validations/` files and ask user to select
+- Nothing → list `tmp/github/issue-*/validation.md` files and ask user to select
 
 ## Execution Protocol
 
@@ -105,7 +105,7 @@ After all steps are processed:
 
 - **If passed**: Suggest `gh issue comment NNN --body "Validation passed. All N steps verified."` and update acceptance criteria checkboxes in the issue.
 - **If failed**: Suggest next actions (fix specific steps, re-run with `/run-validation`).
-- Update `tmp/github/progress/issue-NNN-workflow.md` with validation outcome.
+- Update `tmp/github/issue-NNN/workflow.md` with validation outcome.
 
 ## Updating the Validation File
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,16 +145,24 @@ Use `tmp/` for all development scratch files that should NOT be committed. This 
 
 ```
 tmp/
-├── CLAUDE.md              # Instructions for this directory
-├── github/                # GitHub-related drafts
-│   ├── CLAUDE.md
-│   ├── issue-descriptions/  # Cached issue bodies (issue-NNN.md)
-│   ├── issue-comments/      # Draft comments before posting
-│   └── pr-bodies/           # Draft PR descriptions
-├── coverage-reports/      # CI coverage (gh run download); htmlcov/index.html for per-file report
-├── analysis/              # Exploration notes, profiling
-├── debug/                 # Debug output, logs, test artifacts
-└── progress/              # Any other work-in-progress text
+├── CLAUDE.md                     # Instructions for this directory
+├── github/                       # GitHub-related scratch files
+│   ├── issue-NNN/                # All scratch files for issue NNN in one place
+│   │   ├── description.md        # Cached issue body (gh issue view NNN)
+│   │   ├── workflow.md           # Phase tracking, decisions, next steps
+│   │   ├── plan.md               # Implementation plan (Phase 2)
+│   │   ├── validation.md         # Validation document (/create-validation)
+│   │   └── comments/             # Draft comments before posting
+│   │       ├── refinement.md     # Phase 1 refinement comment
+│   │       ├── plan.md           # Phase 2 plan comment
+│   │       ├── milestone.md      # Phase 3 progress comment
+│   │       └── close.md          # Close comment (if issue is obsolete)
+│   ├── open-issues.md            # Cached open issues list (gh issue list)
+│   └── pr-bodies/                # Draft PR descriptions before posting
+├── coverage-reports/             # CI coverage (gh run download); htmlcov/index.html for per-file report
+├── analysis/                     # Exploration notes, profiling
+├── debug/                        # Debug output, logs, test artifacts
+└── drafts/                       # Any other WIP text
 ```
 
 **Rules:**

--- a/docs/validations/README.md
+++ b/docs/validations/README.md
@@ -2,6 +2,19 @@
 
 Committed validation documents for features. These are permanent, version-controlled proofs that an implementation meets its acceptance criteria.
 
+## Linkage Requirement
+
+Every committed validation file must reference the GitHub issue or chore it validates. Add this to the frontmatter or the opening section:
+
+```yaml
+---
+issue: "#NNN"                        # GitHub issue number, OR
+chore: "short-description"           # if no issue was created (e.g. "dependency-upgrade-2026-02")
+---
+```
+
+For session-scoped validations in `tmp/github/issue-NNN/validation.md`, the issue number is implicit from the directory name.
+
 ## When to Commit a Validation
 
 Commit to `docs/validations/` when:
@@ -9,13 +22,13 @@ Commit to `docs/validations/` when:
 - The validation is tied to a demo or portfolio requirement
 - The acceptance criteria are non-trivial and the validation steps represent institutional knowledge
 
-For session-scoped, ephemeral validations (most cases), use `tmp/validations/` instead.
+For most cases, use `tmp/github/issue-NNN/validation.md` (gitignored, issue-scoped) instead.
 
 ## File Naming
 
 ```
 feature-<slug>-validation.md    # e.g. feature-document-upload-validation.md
-issue-NNN-validation.md         # when tied to a specific issue permanently
+issue-NNN-validation.md         # when permanently tied to a specific issue
 ```
 
 ## Format


### PR DESCRIPTION
## Summary

Addresses owner review comments on PR #120. No production code changed.

- **Unified `tmp/` layout**: All issue scratch files under `tmp/github/issue-NNN/` — one directory per issue, no more scattered locations across `issue-descriptions/`, `progress/`, `issue-comments/`, `tmp/validations/`
- **Single source of truth for skills**: `.claude/skills/` stripped to delegation-only (frontmatter + one link); all skill content lives exclusively in `.cursor/skills/`
- **Expanded workflow docs**: `.cursor/commands/README.md` now covers the full 5-phase lifecycle and explicitly distinguishes issue-validation (Phase 1 analysis) from implementation-validation (Phase 4)
- **`docs/validations/README.md`**: Linkage requirement — every committed validation must declare its GitHub issue number or chore slug

## Addresses comments from PR #120

- `.claude/skills/create-validation/SKILL.md` — remove duplicated Quick Reference (Cursor Bugbot divergence risk)
- `.claude/skills/run-validation/SKILL.md` — same
- `.cursor/commands/create-validation.md` — unified tmp file locations
- `.cursor/commands/run-validation.md` — unified tmp file locations
- `.cursor/commands/get-started.md` — unified tmp file locations throughout
- `.cursor/commands/README.md` — detailed get-started workflow, issue-vs-implementation-validation table
- `docs/validations/README.md` — relate to GitHub issue or chore
- `CLAUDE.md` — updated tmp/ structure diagram

## Test plan

- [ ] `uv run pytest` passes (no production code changed)
- [ ] All tmp file path references consistent across CLAUDE.md, commands, and skills

Closes owner review comments on #120