### PR TITLE
#82: Healthcare Clinical Guideline Assistant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,8 @@ requires-python = ">=3.12,<3.14"
 
 # Configure the package to include src directory and make it importable
 [tool.setuptools.packages.find]
-where = ["src", "scripts"]
-include = ["*"]
+where = ["src", "."]
+include = ["scripts", "scripts.*", "authenticate_google_calendar", "backend", "backend.*", "frontend", "frontend.*", "mcp_calendar", "mcp_calendar.*", "wbso", "wbso.*"]
 
 [tool.setuptools.package-data]
 "backend.rag_pipeline" = ["py.typed"]


### PR DESCRIPTION
## Summary

Closes #82

Implements the Healthcare Clinical Guideline Assistant feature for the on-premises RAG system.

- **Fetch script** (`scripts/fetch_healthcare_guidelines.py`): Downloads clinical guideline PDFs (NHG/NICE) for RAG ingestion, with `--output`, `--quiet` flags, success/skip reporting, and `__main__` block
- **Entry point** (`fetch-healthcare-guidelines`): Registered in `pyproject.toml`; fixed editable install mapping so `scripts` package is discoverable outside CWD
- **Benchmark fixture** (`tests/fixtures/healthcare_benchmark_clinical.json`): 10 Q&A pairs for RAG evaluation
- **Tests** (`tests/test_fetch_healthcare_guidelines.py`, `tests/test_evaluation_dataset.py`): 16 tests covering fetch, skip, success report, and benchmark schema validation
- **Demo docs** (`docs/HEALTHCARE_DEMO.md`): End-to-end walkthrough with `fetch-healthcare-guidelines`, `upload-documents`, `evaluate-rag`
- **Parallel test fix**: ChromaDB SQLite lock contention resolved by isolating `CHROMA_PERSIST_DIR` per xdist worker; `-n auto` capped at 8 local workers
- **pyproject.toml fix**: `packages.find.where = ["src", "."]` with explicit include list so the editable finder maps `scripts` correctly

## Test plan

- [x] `uv run python -c "import scripts.fetch_healthcare_guidelines; print('OK')"` → OK
- [x] `uv run fetch-healthcare-guidelines --help` → exit 0, shows `--output`
- [x] Benchmark fixture: 10 queries, all have `question` + `expected_answer`
- [x] `uv run pytest tests/test_fetch_healthcare_guidelines.py tests/test_evaluation_dataset.py` → 16 passed
- [x] Full test suite → 714 passed, 0 failed
- [x] Demo docs reference `fetch-healthcare-guidelines`, `upload-documents`, `evaluate-rag`, NHG/NICE
- [x] `uv run fetch-healthcare-guidelines --help` → exit 0
- [x] `ruff check` on changed files → CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)