### PR TITLE
docs: RAG evaluation run report and README metrics (#133)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,13 @@ uv run evaluate-rag --dataset tests/fixtures/healthcare_benchmark.json --output 
 # Clinical guidelines (NHG): uv run evaluate-rag --dataset tests/fixtures/healthcare_benchmark_clinical.json --output results/eval-clinical
 ```
 
-| Strategy | MRR | Recall@5 | Hit@5 | Precision@5 |
-|----------|-----|----------|-------|-------------|
-| dense    | -   | -        | -     | -           |
-| sparse   | -   | -        | -     | -           |
-| hybrid   | -   | -        | -     | -           |
+| Strategy | MRR   | Recall@5 | Hit@5 | Precision@5 |
+|----------|-------|----------|-------|-------------|
+| dense    | 0.5161 | 0.5161  | 0.5161 | 0.1032     |
+| sparse   | 0.8710 | 0.8710  | 0.8710 | 0.1742     |
+| hybrid   | 0.5898 | 0.9032  | 0.9032 | 0.1806     |
 
-_Table populated after running `uv run evaluate-rag`. Requires ChromaDB with ingested documents._
+_General healthcare benchmark, local run 2026-04-24. See [docs/reports/rag-evaluation-run-2026-04-24.md](docs/reports/rag-evaluation-run-2026-04-24.md) for commit SHA, package versions, and clinical benchmark. Requires ChromaDB with ingested documents to reproduce._
 See [docs/technical/RAG_EVALUATION.md](docs/technical/RAG_EVALUATION.md) for schema and usage.
 See [docs/TECHNICAL_SUMMARY.md](docs/TECHNICAL_SUMMARY.md) for full design document and evaluation run instructions.
 

--- a/docs/TECHNICAL_SUMMARY.md
+++ b/docs/TECHNICAL_SUMMARY.md
@@ -1,7 +1,7 @@
 # On-Premises RAG for Healthcare: Technical Design and Lessons Learned
 
 **Created:** 2026-03-03  
-**Updated:** 2026-03-03
+**Updated:** 2026-04-24
 
 A technical summary of building a production-ready Retrieval-Augmented Generation (RAG) system for regulated healthcare environments. This document is designed as internal documentation that can be converted to a blog post for publishing on a personal site or LinkedIn.
 
@@ -107,6 +107,8 @@ Output includes JSON results and a Markdown table. Example (illustrative; actual
 | dense    | 0.72 | 0.81     | 0.90  | 0.65        |
 | sparse   | 0.58 | 0.69     | 0.82  | 0.52        |
 | hybrid   | 0.85 | 0.88     | 0.93  | 0.71        |
+
+_The table above is an illustrative example. For a dated run with exact versions, commit SHA, and measured metrics, see [reports/rag-evaluation-run-2026-04-24.md](reports/rag-evaluation-run-2026-04-24.md)._
 
 _See [RAG_EVALUATION.md](technical/RAG_EVALUATION.md) for schema and usage._
 

--- a/docs/portfolio/validation/load-testing-and-rag-evaluation-signoff.md
+++ b/docs/portfolio/validation/load-testing-and-rag-evaluation-signoff.md
@@ -1,7 +1,7 @@
 # Load testing and RAG evaluation sign-off
 
 Created: 2026-03-23
-Updated: 2026-03-23
+Updated: 2026-04-24
 
 Automation should already ship **scripts and documentation**. This template is for **human execution** before release or portfolio sign-off when results are environment-dependent.
 
@@ -35,7 +35,7 @@ Notes:
 
 ## RAG evaluation
 
-**References:** [TECHNICAL_SUMMARY.md](../../TECHNICAL_SUMMARY.md), and the GitHub issue for evaluation (exact `uv run` commands).  
+**References:** [TECHNICAL_SUMMARY.md](../../TECHNICAL_SUMMARY.md), and the GitHub issue for evaluation (exact `uv run` commands). **Measured run (versions, SHAs):** [rag-evaluation-run-2026-04-24.md](../../reports/rag-evaluation-run-2026-04-24.md).  
 **GitHub issue (optional):** https://github.com/pkuppens/on_prem_rag/issues/133
 
 | Field | Value |

--- a/docs/reports/rag-evaluation-run-2026-04-24.md
+++ b/docs/reports/rag-evaluation-run-2026-04-24.md
@@ -1,0 +1,58 @@
+# RAG evaluation run (issue #133)
+
+Created: 2026-04-24
+Updated: 2026-04-24
+
+This report records **measured** retrieval metrics from a local run. It is separate from the illustrative example in [../TECHNICAL_SUMMARY.md](../TECHNICAL_SUMMARY.md). Raw CLI outputs for this run are written to `results/eval.*` and `results/eval-clinical.*` (paths are gitignored; values are copied here for the repository record).
+
+## Reproducibility metadata
+
+| Field | Value |
+|-------|--------|
+| Repository | `pkuppens/on_prem_rag` |
+| Git commit (code evaluated) | `853e442a1e8890fed893936c975c7414c49d00a4` |
+| Project version ([pyproject.toml](../../pyproject.toml)) | 0.1.0 |
+| OS | Windows 10.0.26200 (amd64) |
+| Parameter set | `fast` (see [parameter_sets.py](../../src/backend/rag_pipeline/config/parameter_sets.py)) |
+| Embedding model | `sentence-transformers/all-MiniLM-L6-v2` |
+| Chroma collection chunk count (BM25 index) | 5830 |
+| Datasets | [tests/fixtures/healthcare_benchmark.json](../../tests/fixtures/healthcare_benchmark.json), [tests/fixtures/healthcare_benchmark_clinical.json](../../tests/fixtures/healthcare_benchmark_clinical.json) |
+| Ingestion | `uv run fetch-healthcare-guidelines` (11 PDFs in `tmp/healthcare_guidelines`); `uv run upload-documents --direct tmp/healthcare_guidelines` (Windows logged transient path errors; vector store was already populated; re-run on a clean store if you need a clean baseline). |
+
+## Resolved Python packages (excerpt)
+
+Versions from `uv pip list` in the run environment:
+
+| Package | Version |
+|---------|---------|
+| chromadb | 1.1.1 |
+| sentence-transformers | 5.2.2 |
+| torch | 2.10.0 |
+| llama-index | 0.14.3 |
+| llama-index-core | 0.14.14 |
+| llama-index-vector-stores-chroma | 0.5.5 |
+
+## General healthcare benchmark
+
+Command: `uv run evaluate-rag --dataset tests/fixtures/healthcare_benchmark.json --output results/eval`
+
+| Strategy | MRR | Recall@5 | Hit@5 | Precision@5 |
+|----------|-----|----------|-------|-------------|
+| dense | 0.5161 | 0.5161 | 0.5161 | 0.1032 |
+| sparse | 0.8710 | 0.8710 | 0.8710 | 0.1742 |
+| hybrid | 0.5898 | 0.9032 | 0.9032 | 0.1806 |
+
+## NHG clinical benchmark (optional)
+
+Command: `uv run evaluate-rag --dataset tests/fixtures/healthcare_benchmark_clinical.json --output results/eval-clinical`
+
+| Strategy | MRR | Recall@5 | Hit@5 | Precision@5 |
+|----------|-----|----------|-------|-------------|
+| dense | 0.8833 | 1.0000 | 1.0000 | 0.4000 |
+| sparse | 0.1250 | 0.1500 | 0.2000 | 0.0600 |
+| hybrid | 0.5033 | 0.6000 | 0.9000 | 0.2400 |
+
+## Notes
+
+- Metrics depend on the ingested corpus and Chroma state; another machine or a fresh store will not match bit-for-bit without repeating ingestion.
+- The README [RAG Performance](../../README.md#rag-performance) table uses the **general healthcare benchmark** numbers above to match the default `evaluate-rag` example command.


### PR DESCRIPTION
## Summary
- Adds versioned run report at \docs/reports/rag-evaluation-run-2026-04-24.md\ (commit SHA, package versions, general + clinical benchmark tables, environment notes).
- Populates README RAG Performance table from the general healthcare benchmark.
- Distinguishes illustrative vs measured results in \docs/TECHNICAL_SUMMARY.md\; links sign-off doc to the report.

## Issue
Closes #133 (execution was done locally; \esults/*\ remains gitignored per project policy).

## Verification
- \uv run evaluate-rag\ was run for both fixtures; numbers match the committed report and README.


Made with [Cursor](https://cursor.com)