### PR TITLE
feat: Kubernetes deployment manifests for the RAG stack (k8s/)

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,55 @@
+# k8s — Kubernetes manifests for on_prem_rag
+
+Kubernetes deployment of the on-prem RAG stack, derived from `docker-compose.yml`
+and the generic building blocks in [`pkuppens/ckad-catalog`](https://github.com/pkuppens/ckad-catalog).
+Tracks pkuppens/pkuppens#116 (EPIC pkuppens/pkuppens#109).
+
+## Services
+
+| Manifest | Workload | State | Notes |
+| --- | --- | --- | --- |
+| `chroma.yaml` | ChromaDB vector store | Stateful (PVC) | TCP probes |
+| `ollama.yaml` | Ollama LLM runtime | Stateful (PVC) | GPU optional (see comments) |
+| `backend.yaml` | RAG FastAPI backend | Stateless + uploads PVC | `/health` probes, **HPA** |
+| `auth.yaml` | Auth FastAPI service | Stateless | `/oauth/providers` probe |
+| `frontend.yaml` | React/Vite UI | Stateless | served on 5173 |
+| `ingress.yaml` | Ingress | - | `/` -> frontend, `/api` -> backend, `/auth` -> auth |
+
+Config in `configmap.yaml`; LLM keys/JWT secret in `secret.yaml` (PLACEHOLDERS — never commit real values).
+
+## Deploy (local kind)
+
+```powershell
+# build + load images (no registry needed for kind)
+docker build -t onpremrag-backend:dev -f docker/backend/Dockerfile .
+docker build -t onpremrag-frontend:dev -f docker/frontend/Dockerfile .
+kind load docker-image onpremrag-backend:dev onpremrag-frontend:dev --name ckad
+
+kubectl apply -k k8s
+kubectl get pods -n onpremrag
+curl -H "Host: onpremrag.local" http://localhost/
+```
+
+## Scaling showcase
+
+`backend.yaml` ships a HorizontalPodAutoscaler (CPU 70%, 2-6 replicas) so the API
+tier scales independently. This is the CKAD scaling demonstration.
+
+### Follow-up: extract embeddings/STT into a microservice (planned)
+
+Today embeddings and Whisper STT run **in-process** inside the backend (memory/GPU
+heavy). The next step (tracked in pkuppens/pkuppens#116, advanced) is to extract
+them into their own Deployment + Service so they scale and (optionally) schedule on
+GPU nodes independently of the API:
+
+- New `embeddings` Deployment exposing an internal embedding endpoint; backend calls
+  it over HTTP instead of importing the model.
+- Its own HPA and optional GPU `nodeSelector`/`tolerations` + `resources.limits.nvidia.com/gpu`.
+- Requires backend code changes (swap the in-process embedder for an HTTP client),
+  so it is intentionally out of scope for this initial manifest PR.
+
+## Notes
+
+- These manifests are a development baseline (single-replica stateful services). A
+  production setup would add managed/replicated storage, real secrets management,
+  TLS on the Ingress, and resource tuning.

--- a/k8s/auth.yaml
+++ b/k8s/auth.yaml
@@ -1,0 +1,72 @@
+# Auth microservice (separate FastAPI app, same backend image, different command).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth
+  namespace: onpremrag
+  labels:
+    app: auth
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: auth
+  template:
+    metadata:
+      labels:
+        app: auth
+    spec:
+      containers:
+        - name: auth
+          image: onpremrag-backend:dev
+          imagePullPolicy: IfNotPresent
+          command:
+            - uvicorn
+            - src.backend.auth_service.main:app
+            - --host
+            - "0.0.0.0"
+            - --port
+            - "9181"
+          ports:
+            - containerPort: 9181
+          env:
+            - name: PORT
+              value: "9181"
+            - name: ENVIRONMENT
+              value: "development"
+            - name: AUTH_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: onpremrag-secrets
+                  key: AUTH_JWT_SECRET
+          readinessProbe:
+            httpGet:
+              path: /oauth/providers
+              port: 9181
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /oauth/providers
+              port: 9181
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth
+  namespace: onpremrag
+spec:
+  selector:
+    app: auth
+  ports:
+    - port: 9181
+      targetPort: 9181

--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -1,0 +1,125 @@
+# RAG backend (FastAPI). Stateless apart from uploaded files (shared PVC).
+# Image: build docker/backend/Dockerfile and push, or load into kind:
+#   docker build -t onpremrag-backend:dev -f docker/backend/Dockerfile .
+#   kind load docker-image onpremrag-backend:dev --name ckad
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: uploaded-files
+  namespace: onpremrag
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: onpremrag
+  labels:
+    app: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+        - name: backend
+          image: onpremrag-backend:dev
+          imagePullPolicy: IfNotPresent
+          command:
+            - uvicorn
+            - backend.rag_pipeline.api.app:app
+            - --host
+            - "0.0.0.0"
+            - --port
+            - "9180"
+          ports:
+            - containerPort: 9180
+          envFrom:
+            - configMapRef:
+                name: onpremrag-config
+          env:
+            - name: PORT
+              value: "9180"
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: onpremrag-secrets
+                  key: OPENAI_API_KEY
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: onpremrag-secrets
+                  key: ANTHROPIC_API_KEY
+            - name: GOOGLE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: onpremrag-secrets
+                  key: GOOGLE_API_KEY
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 9180
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 9180
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+          volumeMounts:
+            - name: uploads
+              mountPath: /app/uploaded_files
+      volumes:
+        - name: uploads
+          persistentVolumeClaim:
+            claimName: uploaded-files
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: onpremrag
+spec:
+  selector:
+    app: backend
+  ports:
+    - port: 9180
+      targetPort: 9180
+---
+# Independent scaling of the backend (CKAD domain 2/4). Needs metrics-server.
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: backend
+  namespace: onpremrag
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: backend
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/k8s/chroma.yaml
+++ b/k8s/chroma.yaml
@@ -1,0 +1,75 @@
+# Vector store: ChromaDB. Stateful -> PVC. TCP readiness (image lacks curl).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: chroma-data
+  namespace: onpremrag
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chroma
+  namespace: onpremrag
+  labels:
+    app: chroma
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: chroma
+  template:
+    metadata:
+      labels:
+        app: chroma
+    spec:
+      containers:
+        - name: chroma
+          image: chromadb/chroma:latest
+          ports:
+            - containerPort: 8000
+          env:
+            - name: IS_PERSISTENT
+              value: "TRUE"
+          readinessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          volumeMounts:
+            - name: data
+              mountPath: /chroma
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: chroma-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: chroma
+  namespace: onpremrag
+spec:
+  selector:
+    app: chroma
+  ports:
+    - port: 8000
+      targetPort: 8000

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,16 @@
+# Non-secret runtime config for the RAG backend and auth service.
+# Mirrors the environment block of docker-compose.yml (service DNS names instead of host ports).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: onpremrag-config
+  namespace: onpremrag
+data:
+  CHROMA_HOST: "chroma"
+  CHROMA_PORT: "8000"
+  OLLAMA_BASE_URL: "http://ollama:11434"
+  UPLOADED_FILES_DIR: "/app/uploaded_files"
+  ALLOW_ORIGINS: "http://localhost:5173,http://onpremrag.local"
+  ENVIRONMENT: "development"
+  BACKEND_PORT: "9180"
+  AUTH_PORT: "9181"

--- a/k8s/frontend.yaml
+++ b/k8s/frontend.yaml
@@ -1,0 +1,56 @@
+# Frontend (React/Vite). Stateless. Reaches backend/auth via Ingress in-cluster.
+#   docker build -t onpremrag-frontend:dev -f docker/frontend/Dockerfile .
+#   kind load docker-image onpremrag-frontend:dev --name ckad
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: onpremrag
+  labels:
+    app: frontend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: onpremrag-frontend:dev
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5173
+          env:
+            - name: VITE_BACKEND_URL
+              value: "http://onpremrag.local/api"
+            - name: VITE_AUTH_URL
+              value: "http://onpremrag.local/auth"
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 5173
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: onpremrag
+spec:
+  selector:
+    app: frontend
+  ports:
+    - port: 5173
+      targetPort: 5173

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,36 @@
+# Single host routes to frontend, backend (/api) and auth (/auth).
+# Reach with:  curl -H "Host: onpremrag.local" http://localhost/
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: onpremrag
+  namespace: onpremrag
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: onpremrag.local
+      http:
+        paths:
+          - path: /api(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 9180
+          - path: /auth(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: auth
+                port:
+                  number: 9181
+          - path: /()(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 5173

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - secret.yaml
+  - chroma.yaml
+  - ollama.yaml
+  - backend.yaml
+  - auth.yaml
+  - frontend.yaml
+  - ingress.yaml

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: onpremrag

--- a/k8s/ollama.yaml
+++ b/k8s/ollama.yaml
@@ -1,0 +1,71 @@
+# LLM runtime: Ollama. Stateful model cache -> PVC. GPU is optional (see k8s/overlays note).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ollama-data
+  namespace: onpremrag
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama
+  namespace: onpremrag
+  labels:
+    app: ollama
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ollama
+  template:
+    metadata:
+      labels:
+        app: ollama
+    spec:
+      # For GPU scheduling, add (on a GPU node pool):
+      #   nodeSelector: { gpu: "true" }
+      #   tolerations: [{ key: "nvidia.com/gpu", operator: "Exists", effect: "NoSchedule" }]
+      #   and resources.limits: { nvidia.com/gpu: 1 }
+      containers:
+        - name: ollama
+          image: ollama/ollama:latest
+          ports:
+            - containerPort: 11434
+          readinessProbe:
+            tcpSocket:
+              port: 11434
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1Gi
+            limits:
+              cpu: "4"
+              memory: 8Gi
+          volumeMounts:
+            - name: models
+              mountPath: /root/.ollama
+      volumes:
+        - name: models
+          persistentVolumeClaim:
+            claimName: ollama-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama
+  namespace: onpremrag
+spec:
+  selector:
+    app: ollama
+  ports:
+    - port: 11434
+      targetPort: 11434

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,14 @@
+# Cloud LLM API keys and auth secrets (CKAD domain 4: Secret).
+# PLACEHOLDER VALUES ONLY — never commit real keys. On a real cluster, create this
+# Secret out-of-band (kubectl create secret generic ...) or via an external secrets operator.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onpremrag-secrets
+  namespace: onpremrag
+type: Opaque
+stringData:
+  OPENAI_API_KEY: "placeholder-openai-key"
+  ANTHROPIC_API_KEY: "placeholder-anthropic-key"
+  GOOGLE_API_KEY: "placeholder-google-key"
+  AUTH_JWT_SECRET: "placeholder-change-me"


### PR DESCRIPTION
## Summary

Adds a Kubernetes deployment baseline under `k8s/` for the on-prem RAG stack,
derived from `docker-compose.yml` and the generic building blocks in
[pkuppens/ckad-catalog](https://github.com/pkuppens/ckad-catalog).

- Deployments + Services for `chroma`, `ollama`, `backend`, `auth`, `frontend`.
- PVCs for Chroma data, Ollama models, and uploaded files.
- ConfigMap (service DNS, ports) and Secret (LLM keys + JWT — placeholders only).
- Liveness/readiness probes (`/health`, `/oauth/providers`, TCP for chroma/ollama).
- Ingress routing `/` -> frontend, `/api` -> backend, `/auth` -> auth.
- HorizontalPodAutoscaler on the backend (CPU 70%, 2-6) as the scaling showcase.
- `k8s/README.md` documents deploy steps and the planned embeddings/STT microservice extraction (needs backend code changes; out of scope here).

## Validation

- All `k8s/*.yaml` parse cleanly (PyYAML).
- `kubectl kustomize k8s` renders 18 docs (5 Deployments, 5 Services, 3 PVCs, 1 HPA, 1 Ingress, ConfigMap, Secret, Namespace).
- Not yet applied to a live cluster (needs the backend/frontend images built and loaded).

## Notes

- Development baseline: single-replica stateful services, placeholder secrets, no TLS.
- Part of the CKAD portfolio effort. Refs pkuppens/pkuppens#116, EPIC pkuppens/pkuppens#109.
- Origin: Cursor session 2026-05-30, plan `ckad_catalog_and_portfolio_e97596e0`.
