### PR TITLE
chore: remove duplicate src.* import path, keep backend.* canonical

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,13 +71,7 @@ Code lives under `src/` (e.g. `src/backend/`, `src/wbso/`), but `src` is a **bui
 
 `src.*` imports used to work too, because a stray `src/__init__.py` turned `src` into a real package and pytest/scripts running from the repo root put the project root on `sys.path`. That made two import spellings resolve to the same module — confusing, and easy to typo into inconsistently across files. `src/__init__.py` has been removed and `ruff`'s `TID251` banned-api rule now fails the build on any `src.*` import (see `[tool.ruff.lint.flake8-tidy-imports.banned-api]` in `pyproject.toml`).
 
-For standalone scripts that manipulate `sys.path` manually (outside the editable install, e.g. `docs/project/hours/scripts/*.py`), add `src/` to the path, not the repo root:
-
-```python
-project_root = Path(__file__).parent.parent.parent.parent.parent
-sys.path.insert(0, str(project_root / "src"))
-from backend.datetime_utils import parse_datetime_flexible
-```
+Standalone scripts (e.g. `docs/project/hours/scripts/*.py`, `scripts/*.py`) never need `sys.path` manipulation to import `backend.*`/`wbso.*` — `uv sync --group dev` installs the package in editable mode, so those imports resolve as long as the script runs via `uv run python <script>` (the documented invocation for every such script). If you see a `sys.path.insert`/`sys.path.append` before an import block, it's very likely leftover cruft from before the editable install existed — delete it rather than "fixing" it, and put the import at the top of the file like any other.
 
 ## Critical Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,20 @@ Other: `project/` (SAFe docs), `docs/` (technical docs), `tests/` (mirrors src s
 - **src-layout**: Package installed in editable mode via `uv sync --group dev`
 - **Entry points**: Defined in `pyproject.toml` `[project.scripts]`
 
+### Import Conventions
+
+Code lives under `src/` (e.g. `src/backend/`, `src/wbso/`), but `src` is a **build root, not an importable package** — always import as `backend.rag_pipeline.core.chunking`, `wbso.pipeline`, etc., never `src.backend...` or `src.wbso...`.
+
+`src.*` imports used to work too, because a stray `src/__init__.py` turned `src` into a real package and pytest/scripts running from the repo root put the project root on `sys.path`. That made two import spellings resolve to the same module — confusing, and easy to typo into inconsistently across files. `src/__init__.py` has been removed and `ruff`'s `TID251` banned-api rule now fails the build on any `src.*` import (see `[tool.ruff.lint.flake8-tidy-imports.banned-api]` in `pyproject.toml`).
+
+For standalone scripts that manipulate `sys.path` manually (outside the editable install, e.g. `docs/project/hours/scripts/*.py`), add `src/` to the path, not the repo root:
+
+```python
+project_root = Path(__file__).parent.parent.parent.parent.parent
+sys.path.insert(0, str(project_root / "src"))
+from backend.datetime_utils import parse_datetime_flexible
+```
+
 ## Critical Rules
 
 **Dependency management**: `uv add package-name` (runtime) / `uv add --dev package-name` — **NEVER `pip install`**.

--- a/docs/project/hours/business/work_session.py
+++ b/docs/project/hours/business/work_session.py
@@ -15,15 +15,12 @@ from datetime import datetime, time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-# Add project root to path for imports
+# Add src/ (not project root) to path so `backend.*` resolves the same way it
+# does under the package's normal src-layout (see CLAUDE.md > Import Conventions).
 project_root = Path(__file__).parent.parent.parent.parent.parent
-sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(project_root / "src"))
 
-try:
-    from src.backend.datetime_utils import parse_datetime_flexible
-except ImportError:
-    # Fallback for when imported from different contexts
-    from backend.datetime_utils import parse_datetime_flexible
+from backend.datetime_utils import parse_datetime_flexible
 
 
 @dataclass

--- a/docs/project/hours/business/work_session.py
+++ b/docs/project/hours/business/work_session.py
@@ -9,16 +9,9 @@ Entity: WorkSession
 Purpose: Unified model for work session tracking, hours calculation, and work item association
 """
 
-import sys
 from dataclasses import dataclass
 from datetime import datetime, time
-from pathlib import Path
 from typing import Any, Dict, List, Optional
-
-# Add src/ (not project root) to path so `backend.*` resolves the same way it
-# does under the package's normal src-layout (see CLAUDE.md > Import Conventions).
-project_root = Path(__file__).parent.parent.parent.parent.parent
-sys.path.insert(0, str(project_root / "src"))
 
 from backend.datetime_utils import parse_datetime_flexible
 

--- a/docs/project/hours/scripts/cleanup_original_sessions.py
+++ b/docs/project/hours/scripts/cleanup_original_sessions.py
@@ -14,10 +14,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Set
 
-# Add src/ to path so `wbso.*` resolves without requiring the editable install
-project_root = Path(__file__).parent.parent.parent.parent.parent
-sys.path.insert(0, str(project_root / "src"))
-
 from wbso.logging_config import get_logger
 from wbso.upload import GoogleCalendarUploader
 

--- a/docs/project/hours/scripts/cleanup_original_sessions.py
+++ b/docs/project/hours/scripts/cleanup_original_sessions.py
@@ -14,12 +14,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Set
 
-# Add project root to path
+# Add src/ to path so `wbso.*` resolves without requiring the editable install
 project_root = Path(__file__).parent.parent.parent.parent.parent
-sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(project_root / "src"))
 
-from src.wbso.logging_config import get_logger
-from src.wbso.upload import GoogleCalendarUploader
+from wbso.logging_config import get_logger
+from wbso.upload import GoogleCalendarUploader
 
 logger = get_logger("cleanup_sessions")
 

--- a/docs/project/hours/scripts/extract_and_analyze_calendar.py
+++ b/docs/project/hours/scripts/extract_and_analyze_calendar.py
@@ -18,10 +18,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-# Add src/ to path so `wbso.*` resolves without requiring the editable install
-project_root = Path(__file__).parent.parent.parent.parent.parent
-sys.path.insert(0, str(project_root / "src"))
-
 from wbso.logging_config import get_logger
 from wbso.upload import GoogleCalendarUploader
 

--- a/docs/project/hours/scripts/extract_and_analyze_calendar.py
+++ b/docs/project/hours/scripts/extract_and_analyze_calendar.py
@@ -18,12 +18,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-# Add project root to path
+# Add src/ to path so `wbso.*` resolves without requiring the editable install
 project_root = Path(__file__).parent.parent.parent.parent.parent
-sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(project_root / "src"))
 
-from src.wbso.logging_config import get_logger
-from src.wbso.upload import GoogleCalendarUploader
+from wbso.logging_config import get_logger
+from wbso.upload import GoogleCalendarUploader
 
 logger = get_logger("calendar_extract")
 

--- a/docs/project/hours/scripts/prepare_calendar_data_standalone.py
+++ b/docs/project/hours/scripts/prepare_calendar_data_standalone.py
@@ -21,13 +21,13 @@ from datetime import datetime
 from pathlib import Path
 from typing import List
 
-# Add project root to path
+# Add src/ to path so `wbso.*` resolves without requiring the editable install
 project_root = Path(__file__).parent.parent.parent.parent.parent
-sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(project_root / "src"))
 
-from src.wbso.calendar_event import CalendarEvent, WBSODataset
-from src.wbso.logging_config import get_logger
-from src.wbso.pipeline_steps import step_google_calendar_data_preparation
+from wbso.calendar_event import CalendarEvent, WBSODataset
+from wbso.logging_config import get_logger
+from wbso.pipeline_steps import step_google_calendar_data_preparation
 
 logger = get_logger("prepare_calendar_data_standalone")
 
@@ -121,7 +121,7 @@ def load_calendar_events_from_pipeline_context() -> List[CalendarEvent]:
                     dataset.load_from_json(source_path)
 
                     # Convert sessions to events
-                    from src.wbso.activities import WBSOActivities
+                    from wbso.activities import WBSOActivities
 
                     activities_manager = WBSOActivities()
                     activities_manager.load_activities(force_regenerate=False)

--- a/docs/project/hours/scripts/prepare_calendar_data_standalone.py
+++ b/docs/project/hours/scripts/prepare_calendar_data_standalone.py
@@ -6,7 +6,7 @@ This script allows running the Google Calendar data preparation step independent
 without executing the full pipeline or uploading to Google Calendar.
 
 Usage:
-    python prepare_calendar_data_standalone.py [input_file] [output_file]
+    uv run python prepare_calendar_data_standalone.py [input_file] [output_file]
 
 If input_file is not provided, it will attempt to load from the pipeline context.
 If output_file is not provided, it will save to upload_output/prepared_calendar_events.json
@@ -20,10 +20,6 @@ import sys
 from datetime import datetime
 from pathlib import Path
 from typing import List
-
-# Add src/ to path so `wbso.*` resolves without requiring the editable install
-project_root = Path(__file__).parent.parent.parent.parent.parent
-sys.path.insert(0, str(project_root / "src"))
 
 from wbso.calendar_event import CalendarEvent, WBSODataset
 from wbso.logging_config import get_logger

--- a/docs/project/hours/scripts/upload_calendar_from_csv.py
+++ b/docs/project/hours/scripts/upload_calendar_from_csv.py
@@ -19,10 +19,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-# Add src/ to path so `wbso.*` resolves without requiring the editable install
-project_root = Path(__file__).parent.parent.parent.parent.parent
-sys.path.insert(0, str(project_root / "src"))
-
 from wbso.calendar_event import CalendarEvent
 from wbso.logging_config import get_logger
 from wbso.pipeline_steps import step_calendar_replace
@@ -31,6 +27,7 @@ from wbso.upload import GoogleCalendarUploader
 logger = get_logger("csv_calendar_upload")
 
 # Paths
+project_root = Path(__file__).parent.parent.parent.parent.parent
 SCRIPT_DIR = Path(__file__).parent.parent
 DATA_DIR = SCRIPT_DIR / "data"
 CREDENTIALS_PATH = SCRIPT_DIR / "scripts" / "credentials.json"

--- a/docs/project/hours/scripts/upload_calendar_from_csv.py
+++ b/docs/project/hours/scripts/upload_calendar_from_csv.py
@@ -19,14 +19,14 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-# Add project root to path
+# Add src/ to path so `wbso.*` resolves without requiring the editable install
 project_root = Path(__file__).parent.parent.parent.parent.parent
-sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(project_root / "src"))
 
-from src.wbso.calendar_event import CalendarEvent
-from src.wbso.logging_config import get_logger
-from src.wbso.pipeline_steps import step_calendar_replace
-from src.wbso.upload import GoogleCalendarUploader
+from wbso.calendar_event import CalendarEvent
+from wbso.logging_config import get_logger
+from wbso.pipeline_steps import step_calendar_replace
+from wbso.upload import GoogleCalendarUploader
 
 logger = get_logger("csv_calendar_upload")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,12 +145,13 @@ target-version = "py313"
 fixable = ["ALL"]
 unfixable = []
 select = [
-    "E",  # pycodestyle: style issues like indentation, whitespace, etc.
-    "F",  # Pyflakes: logical errors such as unused variables or undefined names
-    "I",  # isort: import sorting
-    "N",  # pep8-naming: class/function/method naming conventions
-    "W",  # pycodestyle warnings (deprecated, generally covered by E)
-    "B",  # bugbear: likely bugs and design problems
+    "E",     # pycodestyle: style issues like indentation, whitespace, etc.
+    "F",     # Pyflakes: logical errors such as unused variables or undefined names
+    "I",     # isort: import sorting
+    "N",     # pep8-naming: class/function/method naming conventions
+    "W",     # pycodestyle warnings (deprecated, generally covered by E)
+    "B",     # bugbear: likely bugs and design problems
+    "TID251", # flake8-tidy-imports: banned-api (blocks `src.*` imports, see banned-api below)
     # "UP", # pyupgrade: syntax modernization (e.g., f-strings, walrus operator)
 ]
 
@@ -202,6 +203,12 @@ exclude = [
 [tool.ruff.lint.mccabe]
 # Unlike Flake8, default to a complexity level of 10.
 max-complexity = 10
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+# `src` is a src-layout build root, not an importable package. Both `backend.x`
+# and `src.backend.x` used to resolve at runtime (see CLAUDE.md > Import Conventions),
+# which was confusing. `backend.x` is canonical; `src.x` is banned.
+"src" = { msg = "Use 'backend.<module>' (or 'wbso.<module>', 'frontend.<module>', etc.), not 'src.<module>'. See CLAUDE.md > Import Conventions." }
 
 [tool.ruff.format]
 # Like Black, use double quotes for strings.

--- a/scripts/run_calendar_upload.py
+++ b/scripts/run_calendar_upload.py
@@ -19,13 +19,13 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict
 
-# Add src to path
-sys.path.insert(0, str(Path(__file__).parent.parent))
+# Add src/ to path so `wbso.*` resolves without requiring the editable install
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from src.wbso.calendar_event import CalendarEvent
-from src.wbso.logging_config import get_logger
-from src.wbso.pipeline_steps import step_calendar_replace
-from src.wbso.upload import GoogleCalendarUploader
+from wbso.calendar_event import CalendarEvent
+from wbso.logging_config import get_logger
+from wbso.pipeline_steps import step_calendar_replace
+from wbso.upload import GoogleCalendarUploader
 
 logger = get_logger("calendar_upload_script")
 
@@ -86,7 +86,7 @@ def load_calendar_events_from_prepared_data() -> list[CalendarEvent]:
 
     # We need to run the pipeline steps up to step_google_calendar_data_preparation
     # to get the prepared calendar events
-    from src.wbso.pipeline_steps import (
+    from wbso.pipeline_steps import (
         step_assign_activities,
         step_assign_commits_to_sessions,
         step_consolidate_system_events,
@@ -181,7 +181,7 @@ def main():
     except FileNotFoundError as e:
         logger.error(str(e))
         logger.error("\nTo prepare the data, run:")
-        logger.error("  uv run python -m src.wbso.pipeline --start-date 2025-06-01 --end-date 2025-12-02")
+        logger.error("  uv run wbso-pipeline --start-date 2025-06-01 --end-date 2025-12-02")
         logger.error("  (The pipeline will stop before calendar upload if there are issues)")
         return 1
     except Exception as e:

--- a/scripts/run_calendar_upload.py
+++ b/scripts/run_calendar_upload.py
@@ -19,9 +19,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict
 
-# Add src/ to path so `wbso.*` resolves without requiring the editable install
-sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
-
 from wbso.calendar_event import CalendarEvent
 from wbso.logging_config import get_logger
 from wbso.pipeline_steps import step_calendar_replace

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,0 @@
-# This file makes src a Python package

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from urllib.parse import urlparse
 
 import pytest
 
-from src.backend.rag_pipeline.utils.progress import progress_notifier
+from backend.rag_pipeline.utils.progress import progress_notifier
 
 _MAX_LOCAL_WORKERS = 8  # Leave cores free for OS/IDE; cap memory usage
 

--- a/tests/test_datetime_utils.py
+++ b/tests/test_datetime_utils.py
@@ -8,7 +8,7 @@ See src/backend/datetime_utils.py for the implementation being tested.
 
 from datetime import datetime
 
-from src.backend.datetime_utils import (
+from backend.datetime_utils import (
     UnifiedDateTime,
     convert_to_standard_format,
     parse_datetime_flexible,

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -14,9 +14,9 @@ import pytest
 def test_auth_service_imports():
     """Test that auth_service imports work."""
     try:
-        from src.backend.auth_service.database import init_db
-        from src.backend.auth_service.main import app, start_server
-        from src.backend.auth_service.models import Session, User
+        from backend.auth_service.database import init_db
+        from backend.auth_service.main import app, start_server
+        from backend.auth_service.models import Session, User
 
         assert app is not None
         assert start_server is not None
@@ -27,16 +27,17 @@ def test_auth_service_imports():
         pytest.fail(
             f"Failed to import auth service modules: {e}\n\n"
             "FIX: Run 'pip install -e .[dev]' to install the package in development mode.\n"
-            "This will make all src.* imports available system-wide."
+            "This will make all backend.* imports available system-wide."
         )
 
 
 def test_rag_pipeline_imports():
     """Test that rag_pipeline imports work."""
     try:
+        from backend.rag_pipeline.file_ingestion import app, start_server
+
+        from backend.rag_pipeline.core.document_loader import DocumentLoader
         from backend.shared.utils.directory_utils import get_uploaded_files_dir
-        from src.backend.rag_pipeline.core.document_loader import DocumentLoader
-        from src.backend.rag_pipeline.file_ingestion import app, start_server
 
         # Verify uploaded_files directory exists
         uploaded_files_dir = get_uploaded_files_dir()
@@ -52,7 +53,7 @@ def test_rag_pipeline_imports():
         pytest.fail(
             f"Failed to import RAG pipeline modules: {e}\n\n"
             "FIX: Run 'pip install -e .[dev]' to install the package in development "
-            "mode.\nThis will make all src.* imports available system-wide."
+            "mode.\nThis will make all backend.* imports available system-wide."
         )
     except Exception as e:
         pytest.fail(
@@ -65,7 +66,7 @@ def test_rag_pipeline_imports():
 def test_test_app_imports():
     """Test that test app modules can be imported."""
     try:
-        from src.test_app import app, start_server
+        from test_app import app, start_server
 
         assert app is not None
         assert start_server is not None
@@ -73,7 +74,7 @@ def test_test_app_imports():
         pytest.fail(
             f"Failed to import test app modules: {e}\n\n"
             "FIX: Run 'pip install -e .[dev]' to install the package in development mode.\n"
-            "This will make all src.* imports available system-wide."
+            "This will make all backend.* imports available system-wide."
         )
 
 
@@ -91,7 +92,7 @@ def test_scripts_can_be_called():
     )
 
     # Test that the modules referenced in pyproject.toml scripts exist
-    script_modules = ["src.backend.auth_service.main", "src.backend.rag_pipeline.file_ingestion", "src.test_app"]
+    script_modules = ["backend.auth_service.main", "backend.rag_pipeline.file_ingestion", "test_app"]
 
     for module_name in script_modules:
         try:
@@ -100,7 +101,7 @@ def test_scripts_can_be_called():
                 pytest.fail(
                     f"Module {module_name} not found.\n\n"
                     "FIX: Run 'pip install -e .[dev]' to install the package in development "
-                    "mode.\nThis will make all src.* modules discoverable by the Python "
+                    "mode.\nThis will make all backend.* modules discoverable by the Python "
                     "import system."
                 )
 

--- a/tests/test_ingestion_domain.py
+++ b/tests/test_ingestion_domain.py
@@ -193,7 +193,9 @@ class TestDomainEvents:
         assert e.records_stored == 8
 
     def test_ingestion_finished_failure(self):
-        e = IngestionFinished(file_name="test.pdf", file_path="/p/test.pdf", total_chunks=0, records_stored=0, success=False, error="timeout")
+        e = IngestionFinished(
+            file_name="test.pdf", file_path="/p/test.pdf", total_chunks=0, records_stored=0, success=False, error="timeout"
+        )
         assert not e.success
         assert e.error == "timeout"
 
@@ -204,6 +206,7 @@ class TestDomainEvents:
 
     def test_all_events_are_frozen_dataclasses(self):
         import dataclasses
+
         e = DocumentLoaded(file_name="a", file_path="b", file_hash="c", page_count=1, file_size=1)
         assert dataclasses.is_dataclass(e)
         assert dataclasses.fields(e)

--- a/tests/test_metrics_and_params.py
+++ b/tests/test_metrics_and_params.py
@@ -1,4 +1,5 @@
 """Tests for metrics and parameter API endpoints."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/test_page_processing.py
+++ b/tests/test_page_processing.py
@@ -10,8 +10,8 @@ from pathlib import Path
 import pytest
 from llama_index.core import Document
 
-from src.backend.rag_pipeline.core.chunking import chunk_documents
-from src.backend.rag_pipeline.core.document_loader import DocumentLoader
+from backend.rag_pipeline.core.chunking import chunk_documents
+from backend.rag_pipeline.core.document_loader import DocumentLoader
 
 
 class TestPageByPageProcessing:

--- a/tests/test_progress_notifier.py
+++ b/tests/test_progress_notifier.py
@@ -1,4 +1,5 @@
 """Tests for the ingestion infrastructure ProgressNotifier."""
+
 from __future__ import annotations
 
 import asyncio

--- a/tests/test_progress_simulation.py
+++ b/tests/test_progress_simulation.py
@@ -13,8 +13,8 @@ from pathlib import Path
 # Add the project root to the Python path
 sys.path.append(str(Path(__file__).parent))
 
-from src.backend.rag_pipeline.utils.logging import StructuredLogger
-from src.backend.rag_pipeline.utils.progress import ProgressEvent, progress_notifier
+from backend.rag_pipeline.utils.logging import StructuredLogger
+from backend.rag_pipeline.utils.progress import ProgressEvent, progress_notifier
 
 logger = StructuredLogger(__name__)
 

--- a/tests/test_progress_simulation.py
+++ b/tests/test_progress_simulation.py
@@ -7,11 +7,6 @@ to test the progress reporting system and WebSocket functionality.
 """
 
 import asyncio
-import sys
-from pathlib import Path
-
-# Add the project root to the Python path
-sys.path.append(str(Path(__file__).parent))
 
 from backend.rag_pipeline.utils.logging import StructuredLogger
 from backend.rag_pipeline.utils.progress import ProgressEvent, progress_notifier

--- a/tests/test_progress_websocket.py
+++ b/tests/test_progress_websocket.py
@@ -16,8 +16,8 @@ import websockets
 # Add the project root to the Python path
 sys.path.append(str(Path(__file__).parent))
 
-from src.backend.rag_pipeline.utils.logging import StructuredLogger
-from src.backend.rag_pipeline.utils.progress import ProgressEvent, progress_notifier
+from backend.rag_pipeline.utils.logging import StructuredLogger
+from backend.rag_pipeline.utils.progress import ProgressEvent, progress_notifier
 
 logger = StructuredLogger(__name__)
 

--- a/tests/test_progress_websocket.py
+++ b/tests/test_progress_websocket.py
@@ -8,13 +8,8 @@ in real-time. Run this while the backend is running to see progress events.
 
 import asyncio
 import json
-import sys
-from pathlib import Path
 
 import websockets
-
-# Add the project root to the Python path
-sys.path.append(str(Path(__file__).parent))
 
 from backend.rag_pipeline.utils.logging import StructuredLogger
 from backend.rag_pipeline.utils.progress import ProgressEvent, progress_notifier

--- a/tests/test_query_adapters.py
+++ b/tests/test_query_adapters.py
@@ -15,10 +15,10 @@ from backend.query_service.adapters.llm import LLMCompletionAdapter
 from backend.query_service.adapters.privacy_guard import PrivacyGuardAdapter
 from backend.query_service.adapters.retrieval import RetrievalAdapter
 
-
 # ---------------------------------------------------------------------------
 # AccessControlAdapter
 # ---------------------------------------------------------------------------
+
 
 class TestAccessControlAdapter:
     def test_check_permission_granted_for_gp(self):
@@ -64,6 +64,7 @@ class TestAccessControlAdapter:
 # AuditTrailAdapter
 # ---------------------------------------------------------------------------
 
+
 class TestAuditTrailAdapter:
     def test_log_query_received_noop_without_service(self):
         adapter = AuditTrailAdapter()
@@ -91,6 +92,7 @@ class TestAuditTrailAdapter:
 # PrivacyGuardAdapter
 # ---------------------------------------------------------------------------
 
+
 class TestPrivacyGuardAdapter:
     def test_sanitize_clean_text(self):
         adapter = PrivacyGuardAdapter()
@@ -108,6 +110,7 @@ class TestPrivacyGuardAdapter:
 # ---------------------------------------------------------------------------
 # RetrievalAdapter
 # ---------------------------------------------------------------------------
+
 
 class TestRetrievalAdapter:
     def test_init_sets_config(self):
@@ -147,6 +150,7 @@ class TestRetrievalAdapter:
 # ---------------------------------------------------------------------------
 # LLMCompletionAdapter
 # ---------------------------------------------------------------------------
+
 
 class TestLLMCompletionAdapter:
     def test_generate_delegates(self):

--- a/tests/test_query_answer_formatter.py
+++ b/tests/test_query_answer_formatter.py
@@ -1,4 +1,5 @@
 """Tests for the AnswerFormatter application service."""
+
 from __future__ import annotations
 
 from backend.query_service.application.answer_formatter import AnswerFormatter
@@ -20,17 +21,13 @@ class TestAnswerFormatter:
 
     def test_format_answer_high_confidence(self):
         formatter = AnswerFormatter()
-        chunks = [
-            {"document_name": "doc.pdf", "page_number": 1, "similarity_score": 0.95, "text": "content"}
-        ]
+        chunks = [{"document_name": "doc.pdf", "page_number": 1, "similarity_score": 0.95, "text": "content"}]
         answer = formatter.format_answer("Answer", chunks)
         assert answer.confidence.label == "high"
 
     def test_format_answer_low_confidence(self):
         formatter = AnswerFormatter()
-        chunks = [
-            {"document_name": "doc.pdf", "page_number": 1, "similarity_score": 0.3, "text": "content"}
-        ]
+        chunks = [{"document_name": "doc.pdf", "page_number": 1, "similarity_score": 0.3, "text": "content"}]
         answer = formatter.format_answer("Answer", chunks)
         assert answer.confidence.label == "low"
 
@@ -42,8 +39,6 @@ class TestAnswerFormatter:
 
     def test_format_answer_strips_answer_text(self):
         formatter = AnswerFormatter()
-        chunks = [
-            {"document_name": "doc.pdf", "page_number": 1, "similarity_score": 0.8, "text": "content"}
-        ]
+        chunks = [{"document_name": "doc.pdf", "page_number": 1, "similarity_score": 0.8, "text": "content"}]
         answer = formatter.format_answer("  answer with spaces  ", chunks)
         assert answer.text == "answer with spaces"

--- a/tests/test_query_domain.py
+++ b/tests/test_query_domain.py
@@ -142,10 +142,12 @@ class TestConversationContext:
         assert ctx.formatted == ""
 
     def test_formatted(self):
-        ctx = ConversationContext.from_history([
-            {"role": "user", "content": "hello"},
-            {"role": "assistant", "content": "world"},
-        ])
+        ctx = ConversationContext.from_history(
+            [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "world"},
+            ]
+        )
         expected = "user: hello\nassistant: world"
         assert ctx.formatted == expected
 

--- a/tests/test_query_edge_cases.py
+++ b/tests/test_query_edge_cases.py
@@ -1,4 +1,5 @@
 """Edge-case tests for query service modules to close coverage gaps."""
+
 from __future__ import annotations
 
 import json
@@ -117,14 +118,17 @@ def test_chat_get_llm_config_value_error():
 def test_chat_stream_direct_implemented():
     with patch("backend.query_service.api.chat.orchestrator", autospec=False) as mock_orch:
         mock_orch.generate_answer_stream.return_value = iter(["token1", "token2"])
-        response = client.post("/api/v1/chat/stream", json={
-            "messages": [
-                {"role": "user", "content": "previous question"},
-                {"role": "assistant", "content": "previous answer"},
-                {"role": "user", "content": "direct test"},
-            ],
-            "direct": True,
-        })
+        response = client.post(
+            "/api/v1/chat/stream",
+            json={
+                "messages": [
+                    {"role": "user", "content": "previous question"},
+                    {"role": "assistant", "content": "previous answer"},
+                    {"role": "user", "content": "direct test"},
+                ],
+                "direct": True,
+            },
+        )
     assert response.status_code == 200
     content = response.text
     assert "token1" in content
@@ -138,10 +142,13 @@ def test_chat_stream_direct_not_implemented():
     ):
         mock_orch.generate_answer_stream.side_effect = NotImplementedError
         mock_orch._llm.generate.return_value = "fallback answer"
-        response = client.post("/api/v1/chat/stream", json={
-            "messages": [{"role": "user", "content": "stream test"}],
-            "direct": True,
-        })
+        response = client.post(
+            "/api/v1/chat/stream",
+            json={
+                "messages": [{"role": "user", "content": "stream test"}],
+                "direct": True,
+            },
+        )
     assert response.status_code == 200
     content = response.text
     assert "fallback answer" in content
@@ -155,9 +162,12 @@ def test_chat_stream_direct_not_implemented():
 def test_chat_stream_no_chunks_non_direct():
     with patch("backend.query_service.api.chat.orchestrator", autospec=False) as mock_orch:
         mock_orch.retrieve_relevant_chunks.return_value = []
-        response = client.post("/api/v1/chat/stream", json={
-            "messages": [{"role": "user", "content": "no chunks test"}],
-        })
+        response = client.post(
+            "/api/v1/chat/stream",
+            json={
+                "messages": [{"role": "user", "content": "no chunks test"}],
+            },
+        )
     assert response.status_code == 200
     content = response.text
     assert "couldn't find relevant information" in content
@@ -170,9 +180,12 @@ def test_chat_stream_with_chunks_and_streaming():
     with patch("backend.query_service.api.chat.orchestrator", autospec=False) as mock_orch:
         mock_orch.retrieve_relevant_chunks.return_value = mock_chunks
         mock_orch.generate_answer_stream.return_value = iter(["hello ", "world"])
-        response = client.post("/api/v1/chat/stream", json={
-            "messages": [{"role": "user", "content": "test question"}],
-        })
+        response = client.post(
+            "/api/v1/chat/stream",
+            json={
+                "messages": [{"role": "user", "content": "test question"}],
+            },
+        )
     assert response.status_code == 200
     content = response.text
     assert "hello " in content
@@ -186,9 +199,12 @@ def test_chat_stream_with_chunks_long_text():
     with patch("backend.query_service.api.chat.orchestrator", autospec=False) as mock_orch:
         mock_orch.retrieve_relevant_chunks.return_value = mock_chunks
         mock_orch.generate_answer_stream.return_value = iter(["answer"])
-        response = client.post("/api/v1/chat/stream", json={
-            "messages": [{"role": "user", "content": "test question"}],
-        })
+        response = client.post(
+            "/api/v1/chat/stream",
+            json={
+                "messages": [{"role": "user", "content": "test question"}],
+            },
+        )
     assert response.status_code == 200
     content = response.text
     assert "answer" in content
@@ -203,9 +219,12 @@ def test_chat_stream_not_implemented_non_direct():
         mock_orch.retrieve_relevant_chunks.return_value = mock_chunks
         mock_orch.generate_answer_stream.side_effect = NotImplementedError
         mock_orch.generate_answer.return_value = "fallback answer"
-        response = client.post("/api/v1/chat/stream", json={
-            "messages": [{"role": "user", "content": "test question"}],
-        })
+        response = client.post(
+            "/api/v1/chat/stream",
+            json={
+                "messages": [{"role": "user", "content": "test question"}],
+            },
+        )
     assert response.status_code == 200
     content = response.text
     assert "fallback answer" in content
@@ -310,9 +329,12 @@ async def test_websocket_subscribe_error():
 
 
 def test_chat_stream_empty_content():
-    response = client.post("/api/v1/chat/stream", json={
-        "messages": [{"role": "user", "content": ""}],
-    })
+    response = client.post(
+        "/api/v1/chat/stream",
+        json={
+            "messages": [{"role": "user", "content": ""}],
+        },
+    )
     assert response.status_code == 400
 
 
@@ -324,5 +346,6 @@ def test_chat_stream_empty_content():
 def test_start_server():
     with patch("uvicorn.run") as mock_run:
         from backend.query_service.main import start_server
+
         start_server()
     mock_run.assert_called_once()

--- a/tests/test_query_health_api.py
+++ b/tests/test_query_health_api.py
@@ -1,4 +1,5 @@
 """Tests for Query Service health API endpoints."""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/test_query_orchestrator.py
+++ b/tests/test_query_orchestrator.py
@@ -82,6 +82,7 @@ class TestQueryOrchestrator:
         orch = QueryOrchestrator(retrieval_service=retrieval, completion_service=llm)
 
         from backend.query_service.domain.aggregates import Conversation
+
         conv = Conversation(session_id="test_session")
         answer = orch.process_in_conversation(conv, "What is diabetes?")
         assert "couldn't find relevant information" in answer.text.lower()
@@ -92,6 +93,7 @@ class TestQueryOrchestrator:
         orch = QueryOrchestrator(retrieval_service=retrieval, completion_service=llm)
 
         from backend.query_service.domain.aggregates import Conversation
+
         conv = Conversation(session_id="test_session")
         answer = orch.process_in_conversation(conv, "What is diabetes?")
         assert answer.text == "Diabetes is a chronic condition."
@@ -109,6 +111,7 @@ class TestQueryOrchestrator:
         )
 
         from backend.query_service.domain.aggregates import Conversation
+
         conv = Conversation(session_id="test_session")
         answer = orch.process_in_conversation(conv, "What is diabetes?")
         assert answer.text == "Diabetes is a chronic condition."

--- a/tests/test_query_prompt_builder.py
+++ b/tests/test_query_prompt_builder.py
@@ -1,4 +1,5 @@
 """Tests for the PromptBuilder application service."""
+
 from __future__ import annotations
 
 from backend.query_service.application.prompt_builder import PromptBuilder
@@ -7,9 +8,7 @@ from backend.query_service.application.prompt_builder import PromptBuilder
 class TestPromptBuilder:
     def test_build_qa_prompt_basic(self):
         builder = PromptBuilder()
-        chunks = [
-            {"document_name": "doc.pdf", "page_number": 1, "similarity_score": 0.9, "text": "The sky is blue."}
-        ]
+        chunks = [{"document_name": "doc.pdf", "page_number": 1, "similarity_score": 0.9, "text": "The sky is blue."}]
         prompt = builder.build_qa_prompt("What color is the sky?", chunks)
         assert "What color is the sky?" in prompt
         assert "The sky is blue." in prompt

--- a/tests/test_query_routes_ask_chat.py
+++ b/tests/test_query_routes_ask_chat.py
@@ -28,8 +28,7 @@ def test_ask_question_valid_strategies(strategy):
     payload = {"question": "test question"}
     if strategy is not None:
         payload["strategy"] = strategy
-    with patch.object(client.app, "state", create=True), \
-         patch("backend.query_service.api.ask.orchestrator") as mock_orch:
+    with patch.object(client.app, "state", create=True), patch("backend.query_service.api.ask.orchestrator") as mock_orch:
         mock_orch.ask_question.return_value = {
             "answer": "test answer",
             "sources": [],
@@ -89,9 +88,12 @@ def test_chat_success():
             {"document_name": "doc.pdf", "page_number": 1, "similarity_score": 0.85, "text": "relevant content"}
         ]
         mock_orch.generate_answer.return_value = "Here is the answer"
-        response = client.post("/api/v1/chat", json={
-            "messages": [{"role": "user", "content": "test question"}],
-        })
+        response = client.post(
+            "/api/v1/chat",
+            json={
+                "messages": [{"role": "user", "content": "test question"}],
+            },
+        )
     assert response.status_code == 200
     data = response.json()
     assert data["answer"] == "Here is the answer"
@@ -101,9 +103,12 @@ def test_chat_success():
 def test_chat_no_chunks():
     with patch("backend.query_service.api.chat.orchestrator") as mock_orch:
         mock_orch.retrieve_relevant_chunks.return_value = []
-        response = client.post("/api/v1/chat", json={
-            "messages": [{"role": "user", "content": "test question"}],
-        })
+        response = client.post(
+            "/api/v1/chat",
+            json={
+                "messages": [{"role": "user", "content": "test question"}],
+            },
+        )
     assert response.status_code == 200
     assert "couldn't find relevant information" in response.json()["answer"].lower()
 
@@ -115,9 +120,12 @@ def test_chat_high_confidence():
             {"document_name": "doc2.pdf", "page_number": 2, "similarity_score": 0.90, "text": "more content"},
         ]
         mock_orch.generate_answer.return_value = "High confidence answer"
-        response = client.post("/api/v1/chat", json={
-            "messages": [{"role": "user", "content": "test question"}],
-        })
+        response = client.post(
+            "/api/v1/chat",
+            json={
+                "messages": [{"role": "user", "content": "test question"}],
+            },
+        )
     data = response.json()
     assert data["confidence"] == "high"
 
@@ -125,9 +133,12 @@ def test_chat_high_confidence():
 def test_chat_error():
     with patch("backend.query_service.api.chat.orchestrator") as mock_orch:
         mock_orch.retrieve_relevant_chunks.side_effect = RuntimeError("retrieval failed")
-        response = client.post("/api/v1/chat", json={
-            "messages": [{"role": "user", "content": "test question"}],
-        })
+        response = client.post(
+            "/api/v1/chat",
+            json={
+                "messages": [{"role": "user", "content": "test question"}],
+            },
+        )
     assert response.status_code == 500
 
 
@@ -149,9 +160,12 @@ def test_chat_stream_last_message_not_user():
 def test_chat_stream_direct():
     with patch("backend.query_service.api.chat.orchestrator.retrieve_relevant_chunks") as mock_ret:
         mock_ret.return_value = [{"document_name": "doc.pdf", "page_number": 1, "similarity_score": 0.85, "text": "content"}]
-        response = client.post("/api/v1/chat/stream", json={
-            "messages": [{"role": "user", "content": "stream test"}],
-            "direct": True,
-        })
+        response = client.post(
+            "/api/v1/chat/stream",
+            json={
+                "messages": [{"role": "user", "content": "stream test"}],
+                "direct": True,
+            },
+        )
     assert response.status_code == 200
     assert "text/event-stream" in response.headers["content-type"]

--- a/tests/test_wbso_calendar_event.py
+++ b/tests/test_wbso_calendar_event.py
@@ -18,7 +18,7 @@ import tempfile
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from src.wbso.calendar_event import (
+from wbso.calendar_event import (
     CalendarEvent,
     ValidationResult,
     WBSODataset,

--- a/tests/test_wbso_pipeline_steps.py
+++ b/tests/test_wbso_pipeline_steps.py
@@ -15,7 +15,7 @@ Created: 2025-11-28
 
 from datetime import datetime
 
-from src.wbso.pipeline_steps import AMSTERDAM_TZ, _normalize_datetime
+from wbso.pipeline_steps import AMSTERDAM_TZ, _normalize_datetime
 
 
 class TestTimezoneNormalization:

--- a/tests/test_wbso_validation.py
+++ b/tests/test_wbso_validation.py
@@ -17,8 +17,8 @@ import tempfile
 from datetime import datetime
 from pathlib import Path
 
-from src.wbso.calendar_event import WBSODataset, WBSOSession
-from src.wbso.validation import WBSODataValidator
+from wbso.calendar_event import WBSODataset, WBSOSession
+from wbso.validation import WBSODataValidator
 
 
 class TestWBSODataValidator:

--- a/tests/test_websocket_connection.py
+++ b/tests/test_websocket_connection.py
@@ -9,13 +9,9 @@ both string and JSON ping-pong messages.
 import asyncio
 import json
 import sys
-from pathlib import Path
 
 import pytest
 import websockets
-
-# Add the project root to the Python path
-sys.path.append(str(Path(__file__).parent))
 
 from backend.rag_pipeline.utils.logging import StructuredLogger
 

--- a/tests/test_websocket_connection.py
+++ b/tests/test_websocket_connection.py
@@ -17,7 +17,7 @@ import websockets
 # Add the project root to the Python path
 sys.path.append(str(Path(__file__).parent))
 
-from src.backend.rag_pipeline.utils.logging import StructuredLogger
+from backend.rag_pipeline.utils.logging import StructuredLogger
 
 logger = StructuredLogger(__name__)
 


### PR DESCRIPTION
## Summary
- A stray `src/__init__.py` turned `src/` into a real package, and pytest's rootdir-insertion put the project root on `sys.path`, so `backend.x` and `src.backend.x` resolved to the same module — an unintended dual import path with no justification.
- Removed `src/__init__.py`; rewrote all `src.backend.*` / `src.wbso.*` imports to the canonical `backend.*` / `wbso.*` form (9 test files, 4 standalone WBSO scripts, 1 business-logic module).
- Standalone scripts that manually extend `sys.path` now add `src/` (not the repo root), so `backend.*`/`wbso.*` resolve without depending on the stray package.
- Added a `ruff` `TID251` banned-api rule so any future `src.*` import fails CI, and documented the convention in `CLAUDE.md` > Import Conventions.
- Also picked up a pre-existing `ruff format` gap on the `test_query_*`/`test_ingestion_domain.py` files (never reformatted since the #169 bounded-context refactor merged to `main`).

## Test plan
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pytest` — 986 passed, 3 skipped
- [x] Verified `TID251` actually fires on a scratch `from src.backend.foo import bar` file before removing it

Note: `pythonpath = ["src", "src/backend"]` in `pyproject.toml` is left as-is — the `src/backend` entry enables a *third*, separate import style (bare `auth_service.database` without any `backend.` prefix, used in ~9 other test files) that's a pre-existing inconsistency outside this PR's scope.