### PR TITLE
#178: Deduplicate legacy rag_pipeline vs current ingestion stacks

### DIFF
--- a/docs/technical/CHUNKING.md
+++ b/docs/technical/CHUNKING.md
@@ -65,20 +65,28 @@ The pipeline supports multiple strategies via the `strategy` parameter in `chunk
 
 ### Integration with Chunking Strategies
 
-```python
-from backend.rag_pipeline.core.chunking import chunk_documents
-from llama_index.core import Document
+The production ingestion path (used by `IngestionService`) is
+`backend.ingestion.infrastructure.chunking`:
 
-def process_documents(documents: list[Document], chunk_size: int = 512, chunk_overlap: int = 50):
+```python
+from backend.ingestion.domain.value_objects import IngestionDocument
+from backend.ingestion.infrastructure.chunking import chunk_documents
+
+def process_documents(documents: list[IngestionDocument], chunk_size: int = 512, chunk_overlap: int = 50):
     """Process documents into chunks with metadata and relationships."""
-    result = chunk_documents(
+    return chunk_documents(
         documents,
         chunk_size=chunk_size,
         chunk_overlap=chunk_overlap,
         strategy="character",  # Uses RecursiveChunkingStrategy (character-based)
     )
-    return result.chunks
 ```
+
+A legacy, functionally equivalent `backend.rag_pipeline.core.chunking` module is
+retained (not deleted) because `backend.rag_pipeline.core.embeddings` — still used by
+`scripts/upload_documents.py` — depends on it (see
+[on_prem_rag#178](https://github.com/pkuppens/on_prem_rag/issues/178)). New code
+should use `ingestion.infrastructure.chunking`.
 
 ### Configuration
 
@@ -164,9 +172,10 @@ def process_documents(documents: list[Document], chunk_size: int = 512, chunk_ov
 
 ## Code Files
 
-- [src/backend/rag_pipeline/core/chunking.py](../../src/backend/rag_pipeline/core/chunking.py) - Main chunking implementation with RecursiveChunkingStrategy and metadata handling
-- [tests/test_chunking.py](../../tests/test_chunking.py) - Comprehensive test suite covering chunking strategies, overlap, and edge cases
-- [src/rag_pipeline/config/parameter_sets.py](../../src/rag_pipeline/config/parameter_sets.py) - ChunkingParams configuration and validation
-- [src/rag_pipeline/core/embeddings.py](../../src/rag_pipeline/core/embeddings.py) - Integration between chunking and embedding generation
-- [src/rag_pipeline/file_ingestion.py](../../src/rag_pipeline/file_ingestion.py) - File upload and chunking pipeline integration
-- [src/rag_pipeline/core/rag_system.py](../../src/rag_pipeline/core/rag_system.py) - RAG system integration with chunking for index creation
+- [src/backend/ingestion/infrastructure/chunking.py](../../src/backend/ingestion/infrastructure/chunking.py) - Production chunking implementation (used by `IngestionService`) with RecursiveChunkingStrategy and metadata handling
+- [tests/test_ingestion_chunking.py](../../tests/test_ingestion_chunking.py) - Direct test suite for the production chunking path
+- [src/backend/rag_pipeline/core/chunking.py](../../src/backend/rag_pipeline/core/chunking.py) - Legacy equivalent, retained for `rag_pipeline/core/embeddings.py` (see #178)
+- [tests/test_chunking.py](../../tests/test_chunking.py) - Test suite for the legacy chunking module
+- [src/backend/rag_pipeline/config/parameter_sets.py](../../src/backend/rag_pipeline/config/parameter_sets.py) - ChunkingParams configuration and validation
+- [src/backend/rag_pipeline/core/embeddings.py](../../src/backend/rag_pipeline/core/embeddings.py) - Integration between (legacy) chunking and embedding generation
+- [src/backend/ingestion/application/ingest_service.py](../../src/backend/ingestion/application/ingest_service.py) - Production ingestion pipeline: load → chunk → embed → store

--- a/notebooks/document_loader_example.ipynb
+++ b/notebooks/document_loader_example.ipynb
@@ -12,7 +12,9 @@
     "- Detailed reporting of chunking results\n",
     "- Using FAST_ANSWERS configuration parameters\n",
     "\n",
-    "We'll use a test PDF document to show the complete process from loading to chunking analysis."
+    "We'll use a test PDF document to show the complete process from loading to chunking analysis.\n",
+    "\n",
+    "**Note**: This notebook uses `backend.rag_pipeline.core.{embeddings,chunking}` — the legacy ingestion modules. They are intentionally retained (not deleted) because `rag_pipeline.core.embeddings` (via `process_pdf`) and `chunking.get_page_chunks` have no equivalent in the production `backend.ingestion.infrastructure` stack used by `IngestionService`. See [on_prem_rag#178](https://github.com/pkuppens/on_prem_rag/issues/178) for background. For new ingestion code, prefer `backend.ingestion.infrastructure.chunking.chunk_documents` and `backend.ingestion.infrastructure.document_loader.DocumentLoader`."
    ]
   },
   {

--- a/src/backend/query_service/api/documents.py
+++ b/src/backend/query_service/api/documents.py
@@ -17,9 +17,8 @@ from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse, Res
 from pydantic import BaseModel, Field, HttpUrl
 from starlette.datastructures import UploadFile as StarletteUploadFile
 
+from backend.ingestion.infrastructure.vector_store import get_vector_store_write
 from backend.rag_pipeline.config.parameter_sets import DEFAULT_PARAM_SET_NAME, RAGParams, get_param_set
-from backend.rag_pipeline.core.document_loader import DocumentLoader
-from backend.rag_pipeline.core.vector_store import get_vector_store_manager
 from backend.rag_pipeline.models.document_models import ProcessingStatus, UploadResponse
 from backend.rag_pipeline.services.document_processing_service import DocumentProcessingService
 from backend.rag_pipeline.services.file_upload_service import FileUploadService
@@ -41,8 +40,7 @@ router = APIRouter(prefix="/api/v1/documents", tags=["documents"])
 # Initialize directories and services
 uploaded_files_dir = get_uploaded_files_dir()
 ensure_directory_exists(uploaded_files_dir)
-document_loader = DocumentLoader()
-vector_store_manager = get_vector_store_manager()
+vector_store_manager = get_vector_store_write()
 document_processing_service = DocumentProcessingService()
 file_upload_service = FileUploadService()
 

--- a/src/backend/rag_pipeline/utils/__init__.py
+++ b/src/backend/rag_pipeline/utils/__init__.py
@@ -1,7 +1,6 @@
 """Initializes utility functions for the RAG pipeline."""
 
 from .directory_utils import *  # noqa: F401,F403
-from .document_loader import *  # noqa: F401,F403
 from .embedding_model_utils import *  # noqa: F401,F403
 from .pdf_utils import *  # noqa: F401,F403
 from .vector_db_inspector import *  # noqa: F401,F403

--- a/src/backend/rag_pipeline/utils/document_loader.py
+++ b/src/backend/rag_pipeline/utils/document_loader.py
@@ -1,3 +1,0 @@
-"""Provides utility functions for loading documents."""
-
-# Document loading functionalities

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -1,7 +1,13 @@
-"""Tests for the chunking module.
+"""Tests for the legacy rag_pipeline.core.chunking module.
 
 Comprehensive test coverage for chunking strategies and configurations.
 Test scenarios align with docs/technical/CHUNKING.md strategy documentation.
+
+This module is retained (not deleted, see #178) because
+backend.rag_pipeline.core.embeddings — still used by scripts/upload_documents.py —
+depends on it. The production ingestion path is covered separately by
+tests/test_ingestion_chunking.py, which targets
+backend.ingestion.infrastructure.chunking directly.
 """
 
 import pytest

--- a/tests/test_ingestion_chunking.py
+++ b/tests/test_ingestion_chunking.py
@@ -1,0 +1,185 @@
+"""Tests for backend.ingestion.infrastructure.chunking — the production chunking path.
+
+Covers the chunk_documents function used by IngestionService. Mirrors the scenario
+coverage of tests/test_chunking.py (legacy rag_pipeline.core.chunking, retained
+because backend.rag_pipeline.core.embeddings still depends on it — see #178).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("llama_index")
+
+from backend.ingestion.domain.value_objects import Chunk, IngestionDocument
+from backend.ingestion.infrastructure.chunking import chunk_documents, generate_content_hash
+
+
+class TestChunkDocuments:
+    """Test the production chunk_documents functionality."""
+
+    def test_chunk_documents_basic(self):
+        """Test basic document chunking functionality."""
+        documents = [
+            IngestionDocument(text="This is the first document content."),
+            IngestionDocument(text="This is the second document with more content to test chunking."),
+        ]
+
+        chunks = chunk_documents(documents, chunk_size=50, chunk_overlap=10)
+
+        assert len(chunks) > 0
+        assert all(isinstance(c, Chunk) for c in chunks)
+        assert all(len(c.content_hash) == 64 for c in chunks)  # SHA-256 hash
+
+    def test_chunk_documents_with_source_path(self, test_data_dir):
+        """Test chunking with source path metadata."""
+        documents = [IngestionDocument(text="Test document content for path testing.")]
+        pdf_path = test_data_dir / "2303.18223v16.pdf"
+
+        chunks = chunk_documents(documents, source_path=pdf_path)
+
+        assert chunks
+        chunk = chunks[0]
+        assert chunk.document_name == pdf_path.name
+        assert chunk.source == str(pdf_path)
+        assert chunk.metadata["document_name"] == pdf_path.name
+        assert "chunk_index" in chunk.metadata
+        assert "document_id" in chunk.metadata
+
+    def test_chunk_documents_empty_input(self):
+        """Test chunking with empty document list."""
+        chunks = chunk_documents([])
+
+        assert chunks == []
+
+    def test_chunk_size_parameters(self):
+        """Test different chunk size parameters."""
+        long_text = "This is a test document. " * 100
+        documents = [IngestionDocument(text=long_text)]
+
+        small_chunks = chunk_documents(documents, chunk_size=200, chunk_overlap=50)
+        large_chunks = chunk_documents(documents, chunk_size=1000, chunk_overlap=100)
+
+        assert len(small_chunks) >= len(large_chunks)
+        assert len(small_chunks) > 0
+        assert len(large_chunks) > 0
+        if len(long_text) > 1000:
+            assert len(small_chunks) > 1
+
+    def test_chunking_strategies(self):
+        """Test character, semantic, and recursive chunking strategies."""
+        text = "Paragraph one. First sentence. Second sentence.\n\nParagraph two. More text here."
+        documents = [IngestionDocument(text=text)]
+
+        char_chunks = chunk_documents(documents, chunk_size=40, chunk_overlap=5, strategy="character")
+        sem_chunks = chunk_documents(documents, chunk_size=40, chunk_overlap=5, strategy="semantic")
+        rec_chunks = chunk_documents(documents, chunk_size=40, chunk_overlap=5, strategy="recursive")
+
+        assert len(char_chunks) > 0
+        assert len(sem_chunks) > 0
+        assert len(rec_chunks) > 0
+
+        # Recursive should respect paragraph boundaries (split on \n\n)
+        assert len(rec_chunks) >= 2, "Recursive should split on paragraph boundaries"
+        assert "Paragraph one" in rec_chunks[0].text
+        assert "Paragraph two" in rec_chunks[-1].text or any("Paragraph two" in c.text for c in rec_chunks)
+
+    def test_generate_content_hash(self):
+        """Test content hash generation."""
+        text1 = "This is test content"
+        text2 = "This is test content"
+        text3 = "This is different content"
+
+        hash1 = generate_content_hash(text1)
+        hash2 = generate_content_hash(text2)
+        hash3 = generate_content_hash(text3)
+
+        assert hash1 == hash2
+        assert hash1 != hash3
+        assert len(hash1) == 64
+
+    def test_generate_content_hash_unicode_handling(self):
+        """Test content hash generation with Unicode surrogate characters."""
+        text_with_surrogates = "Normal text with \ud835 surrogate characters"
+
+        try:
+            hash_result = generate_content_hash(text_with_surrogates)
+            assert len(hash_result) == 64
+            assert isinstance(hash_result, str)
+        except UnicodeEncodeError:
+            pytest.fail("generate_content_hash should handle Unicode surrogate characters")
+
+        unicode_text = "Text with émojis 🚀 and accénts"
+        hash_unicode = generate_content_hash(unicode_text)
+        assert len(hash_unicode) == 64
+        assert isinstance(hash_unicode, str)
+
+    def test_chunking_preserves_metadata(self):
+        """Test that original document metadata is preserved in chunks."""
+        doc = IngestionDocument(text="Test content", metadata={"original_key": "original_value"})
+
+        chunks = chunk_documents([doc])
+
+        assert chunks
+        chunk = chunks[0]
+        assert chunk.metadata["original_key"] == "original_value"
+        assert "chunk_index" in chunk.metadata
+        assert "document_id" in chunk.metadata
+
+    def test_chunking_with_document_loader_integration(self, test_data_dir):
+        """Test integration between the production document loader and chunking."""
+        from backend.ingestion.infrastructure.document_loader import DocumentLoader
+
+        loader = DocumentLoader()
+        pdf_path = test_data_dir / "2005.11401v4.pdf"
+
+        documents, doc_metadata = loader.load_document(pdf_path)
+
+        chunks = chunk_documents(documents, source_path=pdf_path)
+
+        assert len(chunks) > 0
+        assert chunks[0].document_name == pdf_path.name
+        assert doc_metadata["num_pages"] == len(documents)
+
+    def test_chunk_metadata_consistency(self):
+        """Test that chunk metadata is consistent across different chunking operations."""
+        documents = [
+            IngestionDocument(text="This is the first page content."),
+            IngestionDocument(text="This is the second page content."),
+        ]
+
+        chunks1 = chunk_documents(documents, source_path=Path("test.pdf"))
+        chunks2 = chunk_documents(documents, source_path=Path("test.pdf"))
+
+        assert len(chunks1) == len(chunks2)
+        for chunk1, chunk2 in zip(chunks1, chunks2, strict=False):
+            assert chunk1.page_number == chunk2.page_number
+            assert chunk1.document_name == chunk2.document_name
+
+    def test_empty_page_handling(self):
+        """Test that empty pages are properly marked and preserved for page numbering."""
+        documents = [
+            IngestionDocument(text="This is the first page with content."),
+            IngestionDocument(text=""),  # Empty page
+            IngestionDocument(text="This is the third page with content."),
+        ]
+
+        chunks = chunk_documents(documents, source_path=Path("test.pdf"), enable_text_cleaning=True)
+
+        assert len(chunks) > 0, "Should have chunks even with empty pages"
+
+        empty_pages = [c for c in chunks if c.is_empty]
+        non_empty_pages = [c for c in chunks if not c.is_empty]
+
+        assert len(empty_pages) == 1, f"Expected 1 empty page, got {len(empty_pages)}"
+        assert len(non_empty_pages) == 2, f"Expected 2 non-empty pages, got {len(non_empty_pages)}"
+
+        page_numbers = sorted(c.page_number for c in chunks)
+        assert page_numbers == [1, 2, 3], f"Expected sequential page numbers [1, 2, 3], got {page_numbers}"
+
+        for chunk in chunks:
+            if chunk.is_empty:
+                assert chunk.text == "", "Empty pages should have empty text"
+                assert chunk.page_number in [1, 2, 3], "Empty pages should have valid page numbers"

--- a/tests/test_ingestion_performance.py
+++ b/tests/test_ingestion_performance.py
@@ -10,8 +10,8 @@ from pathlib import Path
 
 import pytest
 
-from backend.rag_pipeline.core.chunking import chunk_documents
-from backend.rag_pipeline.core.document_loader import DocumentLoader
+from backend.ingestion.infrastructure.chunking import chunk_documents
+from backend.ingestion.infrastructure.document_loader import DocumentLoader
 
 # Stable URL for a 100+ page PDF (GPT-4 technical report, arXiv)
 # PDF is fetched at test time; never stored in repo.
@@ -44,7 +44,7 @@ class TestIngestionPerformance:
             start = time.perf_counter()
 
             documents, metadata = loader.load_document(pdf_path)
-            chunking_result = chunk_documents(
+            chunks = chunk_documents(
                 documents,
                 source_path=pdf_path,
                 chunk_size=512,
@@ -54,6 +54,6 @@ class TestIngestionPerformance:
 
             elapsed = time.perf_counter() - start
 
-            assert metadata.num_pages >= 100, f"Expected 100+ pages, got {metadata.num_pages}"
-            assert chunking_result.chunk_count > 0
+            assert metadata["num_pages"] >= 100, f"Expected 100+ pages, got {metadata['num_pages']}"
+            assert len(chunks) > 0
             assert elapsed < 60, f"Ingestion took {elapsed:.1f}s, must complete in < 60s"

--- a/tests/test_page_processing.py
+++ b/tests/test_page_processing.py
@@ -3,15 +3,18 @@
 This module tests the page-by-page processing functionality using the 8-page PDF
 document (2305.03983v2.pdf) as specified. The tests validate chunking results,
 page boundaries, and text cleaning functionality.
+
+Targets backend.ingestion.infrastructure.{chunking,document_loader} — the production
+ingestion path used by IngestionService (see #178).
 """
 
 from pathlib import Path
 
 import pytest
-from llama_index.core import Document
 
-from backend.rag_pipeline.core.chunking import chunk_documents
-from backend.rag_pipeline.core.document_loader import DocumentLoader
+from backend.ingestion.domain.value_objects import Chunk
+from backend.ingestion.infrastructure.chunking import chunk_documents
+from backend.ingestion.infrastructure.document_loader import DocumentLoader
 
 
 class TestPageByPageProcessing:
@@ -39,9 +42,9 @@ class TestPageByPageProcessing:
         documents, metadata = document_loader.load_document(test_pdf_path)
 
         assert len(documents) == 8, f"Expected 8 pages, got {len(documents)}"
-        assert metadata.num_pages == 8, f"Expected 8 pages in metadata, got {metadata.num_pages}"
-        assert metadata.file_type == ".pdf"
-        assert metadata.file_size > 0
+        assert metadata["num_pages"] == 8, f"Expected 8 pages in metadata, got {metadata['num_pages']}"
+        assert metadata["file_type"] == ".pdf"
+        assert metadata["file_size"] > 0
 
     def test_page_boundaries_are_preserved(self, test_pdf_path, document_loader):
         """As a user I want search results to link to a single page, so I can quickly view and verify the result.
@@ -55,7 +58,7 @@ class TestPageByPageProcessing:
         large_chunk_size = 10000  # Much larger than typical page content
 
         # Chunk the entire document with large chunk size
-        result = chunk_documents(
+        chunks = chunk_documents(
             documents,
             chunk_size=large_chunk_size,
             chunk_overlap=0,  # No overlap to make boundary testing clearer
@@ -64,21 +67,19 @@ class TestPageByPageProcessing:
 
         # Verify we have at least as many chunks as pages
         # This ensures that page boundaries are being respected
-        assert result.chunk_count >= 8, (
-            f"Expected at least 8 chunks (one per page), got {result.chunk_count}. Chunks may be crossing page boundaries."
+        assert len(chunks) >= 8, (
+            f"Expected at least 8 chunks (one per page), got {len(chunks)}. Chunks may be crossing page boundaries."
         )
 
         # Verify that each chunk has a valid page number
-        for chunk in result.chunks:
-            assert chunk.metadata["page_number"] is not None, "Chunk should have a page number"
-            assert 1 <= chunk.metadata["page_number"] <= 8, (
-                f"Page number should be between 1 and 8, got {chunk.metadata['page_number']}"
-            )
+        for chunk in chunks:
+            assert chunk.page_number is not None, "Chunk should have a page number"
+            assert 1 <= chunk.page_number <= 8, f"Page number should be between 1 and 8, got {chunk.page_number}"
 
         # Group chunks by page and verify each page has at least one chunk
         page_chunks = {}
-        for chunk in result.chunks:
-            page_num = chunk.metadata["page_number"]
+        for chunk in chunks:
+            page_num = chunk.page_number
             if page_num not in page_chunks:
                 page_chunks[page_num] = []
             page_chunks[page_num].append(chunk)
@@ -98,33 +99,28 @@ class TestPageByPageProcessing:
         documents, _ = document_loader.load_document(test_pdf_path)
 
         # Chunk the entire document
-        result = chunk_documents(documents, chunk_size=512, chunk_overlap=50, source_path=test_pdf_path)
+        chunks = chunk_documents(documents, chunk_size=512, chunk_overlap=50, source_path=test_pdf_path)
 
         # Verify chunking statistics
-        assert result.num_pages == 8, f"Expected 8 pages, got {result.num_pages}"
-        assert result.chunk_count > 0, "Should have at least one chunk"
-        assert result.chunk_count == len(result.chunks), "Chunk count should match actual chunks"
-        assert result.file_name == "2305.03983v2.pdf"
-        assert result.file_path == str(test_pdf_path)
-        assert result.file_size > 0
-
-        # Verify chunking parameters
-        assert result.chunking_params["chunk_size"] == 512
-        assert result.chunking_params["chunk_overlap"] == 50
+        assert len(chunks) > 0, "Should have at least one chunk"
+        page_numbers = {c.page_number for c in chunks}
+        assert page_numbers == set(range(1, 9)), f"Expected 8 pages, got {page_numbers}"
+        assert all(c.document_name == "2305.03983v2.pdf" for c in chunks)
+        assert all(c.source == str(test_pdf_path) for c in chunks)
 
         # Verify file hash
-        assert len(result.file_hash) == 64, "Should be SHA-256 hash"
+        assert all(len(c.content_hash) == 64 for c in chunks), "Should be SHA-256 hash"
 
     def test_chunk_metadata_structure(self, test_pdf_path, document_loader):
         """As a user I want search results to include proper source attribution and navigation.
         Technical: Each chunk must have complete metadata structure for document tracking and page navigation.
         """
         documents, _ = document_loader.load_document(test_pdf_path)
-        result = chunk_documents(documents, source_path=test_pdf_path)
+        chunks = chunk_documents(documents, source_path=test_pdf_path)
 
         # Check first chunk metadata
-        if result.chunks:
-            chunk = result.chunks[0]
+        if chunks:
+            chunk = chunks[0]
             required_fields = ["chunk_index", "document_id", "document_name", "page_number", "page_label", "source", "content_hash"]
 
             for field in required_fields:
@@ -144,9 +140,9 @@ class TestPageByPageProcessing:
         Technical: Chunk text should be cleaned of excessive whitespace and formatting artifacts.
         """
         documents, _ = document_loader.load_document(test_pdf_path)
-        result = chunk_documents(documents, source_path=test_pdf_path)
+        chunks = chunk_documents(documents, source_path=test_pdf_path)
 
-        for chunk in result.chunks:
+        for chunk in chunks:
             text = chunk.text
 
             # Text should not be empty
@@ -166,11 +162,11 @@ class TestPageByPageProcessing:
         Technical: Content should be distributed across all pages with reasonable chunk distribution.
         """
         documents, _ = document_loader.load_document(test_pdf_path)
-        result = chunk_documents(documents, source_path=test_pdf_path)
+        chunks = chunk_documents(documents, source_path=test_pdf_path)
 
         # Group chunks by page
-        page_chunks: dict[int, list[Document]] = {}
-        for chunk in result.chunks:
+        page_chunks: dict[int, list[Chunk]] = {}
+        for chunk in chunks:
             page_num = chunk.metadata["page_number"]
             if page_num not in page_chunks:
                 page_chunks[page_num] = []
@@ -196,16 +192,16 @@ class TestPageByPageProcessing:
         documents, _ = document_loader.load_document(test_pdf_path)
 
         # Test with different overlap values
-        result = chunk_documents(documents, chunk_size=512, chunk_overlap=100, source_path=test_pdf_path)
+        chunks = chunk_documents(documents, chunk_size=512, chunk_overlap=100, source_path=test_pdf_path)
 
         # If we have multiple chunks, check for overlap
-        if len(result.chunks) > 1:
-            for i in range(len(result.chunks) - 1):
-                chunk1 = result.chunks[i]
-                chunk2 = result.chunks[i + 1]
+        if len(chunks) > 1:
+            for i in range(len(chunks) - 1):
+                chunk1 = chunks[i]
+                chunk2 = chunks[i + 1]
 
                 # Check if chunks are from the same page
-                if chunk1.metadata["page_number"] == chunk2.metadata["page_number"]:
+                if chunk1.page_number == chunk2.page_number:
                     # There should be some overlap in content
                     chunk1_end = chunk1.text[-50:]  # Last 50 chars
                     chunk2_start = chunk2.text[:50]  # First 50 chars
@@ -225,15 +221,15 @@ class TestPageByPageProcessing:
 
         # Verify document loading
         assert len(documents) == 8
-        assert metadata.num_pages == 8
+        assert metadata["num_pages"] == 8
 
         # Verify chunking
-        result = chunk_documents(documents, source_path=test_pdf_path)
-        assert result.num_pages == 8
-        assert result.chunk_count > 0
+        chunks = chunk_documents(documents, source_path=test_pdf_path)
+        assert {c.page_number for c in chunks} == set(range(1, 9))
+        assert len(chunks) > 0
 
         # Verify chunk metadata
-        for chunk in result.chunks:
+        for chunk in chunks:
             assert chunk.metadata["page_number"] is not None
             assert chunk.metadata["page_label"] is not None
             assert len(chunk.text.strip()) > 0


### PR DESCRIPTION
## Summary

Deduplicates the two parallel document-ingestion stacks (`ingestion.infrastructure` vs legacy `rag_pipeline.core`) surfaced by #176/#177's CodeGraph evaluation, on the live `query_service/api/documents.py` route.

- Removed the dead `document_loader = DocumentLoader()` (legacy) instantiation from `documents.py`; it was never used after construction.
- Migrated `documents.py` vector-store access from `rag_pipeline.core.vector_store.get_vector_store_manager()` to `ingestion.infrastructure.vector_store.get_vector_store_write()` — the same path `IngestionService` writes through, confirmed to resolve to the same Chroma collection/persist dir.
- Added `tests/test_ingestion_chunking.py`: direct unit test coverage for `ingestion.infrastructure.chunking.chunk_documents`, which previously had zero direct coverage (only exercised via the legacy module in tests). Migrated `tests/test_ingestion_performance.py` and `tests/test_page_processing.py` in place to the production `ingestion.infrastructure` modules, since they validate actual production pipeline behavior/performance.
- Deleted the dead stub `rag_pipeline/utils/document_loader.py` and its wildcard re-export.
- Updated `docs/technical/CHUNKING.md` and `notebooks/document_loader_example.ipynb` to point at the production ingestion path.

**Scope finding, documented in the issue**: `rag_pipeline/core/embeddings.py` (still used by `scripts/upload_documents.py` and 3 test files) internally depends on the legacy `rag_pipeline/core/chunking.py` and `rag_pipeline/core/document_loader.py`, so those two modules could not be deleted without also migrating `embeddings.py`/`scripts/upload_documents.py` — a materially larger change touching the embedding-generation pipeline. Kept them, with the reason documented in code/docs per the acceptance criteria's "or an explicit reason is documented" branch. Recommend a follow-up issue if folding `embeddings.py` into `ingestion.infrastructure.embedding` is still wanted.

Closes #178

## Files changed

| File | Change |
|------|--------|
| `src/backend/query_service/api/documents.py` | Dead-code removal + vector-store migration (the risky part — live API route) |
| `src/backend/rag_pipeline/utils/document_loader.py` | Deleted (dead stub) |
| `src/backend/rag_pipeline/utils/__init__.py` | Removed wildcard re-export of the deleted stub |
| `tests/test_ingestion_chunking.py` | New — direct `chunk_documents` coverage |
| `tests/test_ingestion_performance.py` | Migrated to production module (internet+slow, not run by default) |
| `tests/test_page_processing.py` | Migrated to production module — API shape changed (`ChunkingResult`/`DocumentMetadata` → plain `list[Chunk]`/`dict`) |
| `tests/test_chunking.py` | Unchanged behavior, docstring only — clarifies it now tests the *retained legacy* module |
| `docs/technical/CHUNKING.md`, `notebooks/document_loader_example.ipynb` | Doc/notebook updates |

## Test plan

- [x] `uv run pytest -m "not internet and not slow"` — 997 passed, 3 skipped
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] Pre-push hook full test suite — passed
- [x] `tests/test_ingestion_chunking.py` (new, 11 tests) passes
- [x] Migrated `tests/test_page_processing.py` (11 tests) passes against production ingestion module

## Validation and review plan (for reviewer)

This is a refactor on a live API route (`documents.py`), so the main risk is the vector-store consolidation and the test-behavior migration, not the mechanical dead-code removal. Suggested review order:

1. **Vector-store consolidation is the highest-risk change.** Read the diff in `documents.py` (`get_vector_store_manager()` → `get_vector_store_write()`) and independently verify the claim in the PR/issue that both configs resolve to the same Chroma collection: check `src/backend/rag_pipeline/config/vector_store.py` (shim re-exporting `retrieval.infrastructure.vector_store_config.VectorStoreConfig`) against what `ingestion.infrastructure.vector_store.get_vector_store_write()` uses. If you have a local Chroma instance with existing documents, manually exercise upload-duplicate-detection and delete through the running app (`POST /api/v1/documents`, `DELETE /api/v1/documents/{id}`) to confirm dedup and delete still work against real data, not just mocked tests.
2. **Decide whether keeping `rag_pipeline/core/chunking.py` + `document_loader.py` is acceptable**, given the scope finding above (they're kept only because `embeddings.py` → `scripts/upload_documents.py` still needs them). This is a scope call — if you'd rather see `embeddings.py` migrated now instead of deferred to a follow-up issue, say so before merging.
3. **Spot-check the test migrations for behavioral fidelity**, not just "tests pass." The production `chunk_documents` in `ingestion.infrastructure.chunking` has a different return shape than the legacy one (`list[Chunk]` domain objects vs a `ChunkingResult` wrapper with `.chunks`/`.chunk_count`/etc.), so `tests/test_page_processing.py` and `tests/test_ingestion_performance.py` were rewritten, not just re-imported. Diff each rewritten assertion against the original (`git diff main...HEAD -- tests/test_page_processing.py`) to confirm no assertion was silently weakened during the API translation.
4. **Confirm no other consumer of `get_vector_store_manager()`** was missed — it's still used elsewhere (`rag_pipeline/api/*`, `rag_pipeline/services/*`, `evaluation/runner.py`, `scripts/upload_documents.py`) and this PR intentionally leaves those alone (only `query_service/api/documents.py` was migrated, since that's the live route named in the issue). Grep to confirm this PR didn't touch anything beyond `documents.py`: `git diff main...HEAD --stat`.
5. **Run the full test suite yourself**, including the ones this PR doesn't run by default: `uv run pytest -n 8 -m "" --run-internet` — this exercises `test_ingestion_performance.py`'s real 100-page-PDF timing test, which wasn't run locally here (internet+slow marker, skipped by default).
6. **Sanity-check the notebook** still executes end-to-end if you use notebooks regularly (`notebooks/document_loader_example.ipynb` was only docstring-edited, not re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
