### PR TITLE
#175: fix: install a tracked, working pre-push hook on fresh clones

### DIFF
--- a/docs/technical/GIT_HOOKS.md
+++ b/docs/technical/GIT_HOOKS.md
@@ -15,11 +15,14 @@ The project implements a pre-push hook that automatically runs unit tests before
 
 ### Hook Files
 
-The git hook system consists of several files:
+The git hook system consists of:
 
-- `.git/hooks/pre-push` - Shell script for Unix-like systems (Linux, macOS)
-- `.git/hooks/pre-push.ps1` - PowerShell script for Windows
-- `scripts/setup_git_hooks.py` - Cross-platform setup script
+- `githooks/pre-push` - Tracked POSIX shell script; this is the single source of
+  truth for the hook's behavior on both Windows and Unix. Git for Windows invokes
+  hooks through its bundled `sh`, so the same script runs unmodified on both
+  platforms — no OS branching or PowerShell wrapper needed.
+- `scripts/setup_git_hooks.py` - Installs `githooks/pre-push` into
+  `.git/hooks/pre-push` (the actual, untracked, git-managed hooks directory)
 
 ### Setup Process
 
@@ -28,9 +31,12 @@ The git hook system consists of several files:
    uv run python scripts/setup_git_hooks.py
    ```
 
-2. **Manual Setup**: The setup script detects the operating system and installs the appropriate hook:
-   - **Windows**: Creates a batch file wrapper that calls the PowerShell script
-   - **Unix-like**: Copies and makes executable the shell script
+2. The setup script copies the tracked `githooks/pre-push` template to
+   `.git/hooks/pre-push` and marks it executable, then verifies the install by
+   actually executing the hook with `PRE_PUSH_SELF_TEST=1` (which short-circuits
+   to a no-op success) rather than only checking that the file exists — this
+   catches interpreter-resolution failures instead of silently reporting a
+   broken hook as configured.
 
 ### Hook Behavior
 
@@ -42,7 +48,7 @@ The pre-push hook performs the following actions:
    - Validates that `uv` is installed and available
 
 2. **Dependency Installation**:
-   - Runs `uv sync --dev` to ensure all dependencies are installed
+   - Runs `uv sync --group dev` to ensure all dependencies are installed
    - Fails if dependency installation fails
 
 3. **Unit Test Execution**:
@@ -153,11 +159,11 @@ The pre-push hook complements the existing GitHub Actions CI/CD pipeline:
 
 ## Code Files
 
-- [.git/hooks/pre-push](.git/hooks/pre-push) - Unix shell script for pre-push hook
-- [.git/hooks/pre-push.ps1](.git/hooks/pre-push.ps1) - PowerShell script for Windows
-- [scripts/setup_git_hooks.py](scripts/setup_git_hooks.py) - Cross-platform setup script
-- [pyproject.toml](pyproject.toml) - Test configuration and dependencies
-- [.github/workflows/python-ci.yml](.github/workflows/python-ci.yml) - CI/CD pipeline configuration
+- [githooks/pre-push](../../githooks/pre-push) - Tracked POSIX hook script (source of truth)
+- [scripts/setup_git_hooks.py](../../scripts/setup_git_hooks.py) - Setup script; installs the hook and verifies it executes
+- [tests/test_setup_git_hooks.py](../../tests/test_setup_git_hooks.py) - Tests for the install/verify logic
+- [pyproject.toml](../../pyproject.toml) - Test configuration and dependencies
+- [.github/workflows/python-ci.yml](../../.github/workflows/python-ci.yml) - CI/CD pipeline configuration
 
 ## References
 

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -1,0 +1,59 @@
+#!/bin/sh
+# Tracked pre-push hook template — installed into .git/hooks/pre-push by
+# scripts/setup_git_hooks.py. A single POSIX script (not a per-OS branch):
+# Git for Windows invokes hooks through its bundled sh.exe regardless of the
+# user's shell, so this runs unmodified on Windows (Git Bash) and Unix.
+#
+# PRE_PUSH_SELF_TEST=1 short-circuits into a no-op success, used by
+# scripts/setup_git_hooks.py's verify_hook_setup() to prove the hook can
+# actually execute without running the full test suite.
+
+if [ "$PRE_PUSH_SELF_TEST" = "1" ]; then
+    echo "[PRE-PUSH] self-test ok"
+    exit 0
+fi
+
+echo "[PRE-PUSH] Running pre-push checks..."
+
+project_root=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$project_root" ]; then
+    echo "[PRE-PUSH] Not in a git repository."
+    exit 1
+fi
+cd "$project_root" || exit 1
+
+if [ ! -f "pyproject.toml" ]; then
+    echo "[PRE-PUSH] pyproject.toml not found. Are you in the project root?"
+    exit 1
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "[PRE-PUSH] uv is not installed or not on PATH."
+    exit 1
+fi
+
+echo "[PRE-PUSH] Syncing dependencies (uv sync --group dev)..."
+if ! uv sync --group dev; then
+    echo "[PRE-PUSH] Dependency installation failed."
+    exit 1
+fi
+
+echo "[PRE-PUSH] Running ruff check --fix..."
+uv run ruff check --fix .
+
+echo "[PRE-PUSH] Running ruff format..."
+uv run ruff format .
+
+# Auto-stage any files ruff fixed/formatted, matching the behavior
+# setup_git_hooks.py already advertises in its printed instructions.
+git add -u
+
+echo "[PRE-PUSH] Running fast unit tests (uv run pytest -m 'not internet and not slow')..."
+if ! uv run pytest -m "not internet and not slow"; then
+    echo "[PRE-PUSH] Tests failed. Push blocked."
+    echo "[PRE-PUSH] Fix failing tests, or in a genuine emergency: git push --no-verify"
+    exit 1
+fi
+
+echo "[PRE-PUSH] All checks passed."
+exit 0

--- a/scripts/setup_git_hooks.py
+++ b/scripts/setup_git_hooks.py
@@ -1,115 +1,123 @@
 #!/usr/bin/env python3
 """Setup git hooks for the project.
 
-This script sets up the pre-push hook to enforce unit test passing.
-It detects the operating system and sets up the appropriate hook.
+This script installs the tracked ``githooks/pre-push`` template into
+``.git/hooks/pre-push`` to enforce unit test passing before every push.
+The hook itself is a single POSIX script that runs unmodified on both
+Windows (via Git for Windows' bundled ``sh``) and Unix.
 """
 
+from __future__ import annotations
+
 import os
-import platform
 import shutil
 import stat
+import subprocess
 import sys
 from pathlib import Path
 
+EXECUTABLE_MODE = stat.S_IRWXU | stat.S_IRGRP | stat.S_IROTH
 
-def setup_pre_push_hook():
-    """Set up the pre-push hook for enforcing unit tests."""
-    project_root = Path(__file__).parent.parent
+
+def setup_pre_push_hook(project_root: Path | None = None) -> bool:
+    """Install the tracked pre-push hook template into .git/hooks/pre-push."""
+    project_root = project_root or Path(__file__).parent.parent
     hooks_dir = project_root / ".git" / "hooks"
+    hook_source = project_root / "githooks" / "pre-push"
+    hook_target = hooks_dir / "pre-push"
 
     if not hooks_dir.exists():
         print("Error: .git/hooks directory not found. Are you in a git repository?")
         return False
 
-    # Determine the appropriate hook script based on OS
-    system = platform.system().lower()
+    if not hook_source.exists():
+        print(f"Error: hook template not found at {hook_source}")
+        return False
 
-    if system == "windows":
-        # Use PowerShell script for Windows
-        hook_source = project_root / ".git" / "hooks" / "pre-push.ps1"
-        hook_target = hooks_dir / "pre-push"
-
-        # Create a batch file wrapper for Windows
-        batch_content = """@echo off
-powershell.exe -ExecutionPolicy Bypass -File "%~dp0pre-push.ps1" %*
-"""
-        with open(hook_target, "w") as f:
-            f.write(batch_content)
-
-        # Make the batch file executable (Windows doesn't use chmod, but we set it anyway)
-        os.chmod(hook_target, stat.S_IRWXU | stat.S_IRGRP | stat.S_IROTH)
-
-    else:
-        # Use shell script for Unix-like systems
-        hook_source = project_root / ".git" / "hooks" / "pre-push"
-        hook_target = hooks_dir / "pre-push"
-
-        # Copy the shell script
-        shutil.copy2(hook_source, hook_target)
-
-        # Make it executable
-        os.chmod(hook_target, stat.S_IRWXU | stat.S_IRGRP | stat.S_IROTH)
+    shutil.copy2(hook_source, hook_target)
+    os.chmod(hook_target, EXECUTABLE_MODE)
 
     print("[OK] Pre-push hook installed successfully!")
     print(f"   Hook location: {hook_target}")
-    print(f"   System: {system}")
 
     return True
 
 
-def verify_hook_setup():
-    """Verify that the hook is properly set up."""
-    project_root = Path(__file__).parent.parent
+def verify_hook_setup(project_root: Path | None = None) -> bool:
+    """Verify that the hook is installed and can actually execute."""
+    project_root = project_root or Path(__file__).parent.parent
     hook_path = project_root / ".git" / "hooks" / "pre-push"
 
     if not hook_path.exists():
         print("[ERROR] Pre-push hook not found")
         return False
 
-    # Check if it's executable
     if not os.access(hook_path, os.X_OK):
         print("[ERROR] Pre-push hook is not executable")
         return False
 
-    print("[OK] Pre-push hook is properly configured")
+    # Only try "sh": it's what Git for Windows itself uses to run hooks, and is
+    # bundled alongside git regardless of the invoking shell. Falling back to a
+    # generic "bash" lookup risks resolving to an unrelated launcher (e.g. the
+    # Windows/WSL bash stub in System32), which fails on Windows-style paths and
+    # would misreport a working hook as broken.
+    interpreter = shutil.which("sh")
+    if interpreter is None:
+        print("[WARN] Could not find 'sh' on PATH — skipping execution check.")
+        print("       Git itself invokes hooks through its own bundled sh, so this")
+        print("       does not necessarily mean the hook is broken.")
+        print("[OK] Pre-push hook is installed (execution not independently verified)")
+        return True
+
+    result = subprocess.run(
+        [interpreter, str(hook_path)],
+        env={**os.environ, "PRE_PUSH_SELF_TEST": "1"},
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print("[ERROR] Pre-push hook failed to execute (self-test):")
+        print(result.stdout)
+        print(result.stderr)
+        return False
+
+    print("[OK] Pre-push hook is properly configured and executes successfully")
     return True
 
 
-def main():
+def main() -> int:
     """Main function to set up git hooks."""
     print("Setting up git hooks for unit test enforcement...")
 
-    if setup_pre_push_hook():
-        print("\n" + "=" * 60)
-        print("GIT HOOK SETUP COMPLETE")
-        print("=" * 60)
-        print("The pre-push hook will now enforce code quality and unit tests.")
-        print("\nHow it works:")
-        print("• Before every git push, automatic linting and formatting runs")
-        print("  - Runs 'ruff check --fix' to auto-fix linting issues")
-        print("  - Runs 'ruff format' to auto-format code")
-        print("  - Auto-stages any fixed files (no confirmation needed)")
-        print("• Then runs unit tests automatically")
-        print("• If linting or tests fail, the push will be blocked")
-        print("• Only fast unit tests run (excludes slow and internet tests)")
-        print("\nAuto-fixed files:")
-        print("• Files modified by ruff are automatically staged")
-        print("• Review staged changes before pushing if needed")
-        print("\nEmergency bypass option:")
-        print("• Git flag: git push --no-verify")
-        print("\nThis bypass should only be used in emergency situations!")
-        print("=" * 60)
-
-        if verify_hook_setup():
-            print("\n[OK] Setup verification passed!")
-        else:
-            print("\n[ERROR] Setup verification failed!")
-            return 1
-    else:
+    if not setup_pre_push_hook():
         print("[ERROR] Failed to set up git hooks")
         return 1
 
+    print("\n" + "=" * 60)
+    print("GIT HOOK SETUP COMPLETE")
+    print("=" * 60)
+    print("The pre-push hook will now enforce code quality and unit tests.")
+    print("\nHow it works:")
+    print("• Before every git push, automatic linting and formatting runs")
+    print("  - Runs 'ruff check --fix' to auto-fix linting issues")
+    print("  - Runs 'ruff format' to auto-format code")
+    print("  - Auto-stages any fixed files (no confirmation needed)")
+    print("• Then runs unit tests automatically")
+    print("• If linting or tests fail, the push will be blocked")
+    print("• Only fast unit tests run (excludes slow and internet tests)")
+    print("\nAuto-fixed files:")
+    print("• Files modified by ruff are automatically staged")
+    print("• Review staged changes before pushing if needed")
+    print("\nEmergency bypass option:")
+    print("• Git flag: git push --no-verify")
+    print("\nThis bypass should only be used in emergency situations!")
+    print("=" * 60)
+
+    if not verify_hook_setup():
+        print("\n[ERROR] Setup verification failed!")
+        return 1
+
+    print("\n[OK] Setup verification passed!")
     return 0
 
 

--- a/tests/test_setup_git_hooks.py
+++ b/tests/test_setup_git_hooks.py
@@ -1,0 +1,111 @@
+"""Tests for scripts/setup_git_hooks.py.
+
+Covers the fresh-clone install path for issue #175: the tracked
+``githooks/pre-push`` template must be copied byte-for-byte into
+``.git/hooks/pre-push``, made executable, and actually verified to execute
+(not just checked for existence/executable bit).
+"""
+
+import os
+import shutil
+import stat
+from pathlib import Path
+
+import pytest
+
+from scripts.setup_git_hooks import setup_pre_push_hook, verify_hook_setup
+
+REAL_HOOK_SOURCE = Path(__file__).parent.parent / "githooks" / "pre-push"
+
+
+@pytest.fixture
+def fake_project_root(tmp_path: Path) -> Path:
+    """Build a fake project root with .git/hooks/ and a copy of the real hook template."""
+    (tmp_path / ".git" / "hooks").mkdir(parents=True)
+    githooks_dir = tmp_path / "githooks"
+    githooks_dir.mkdir()
+    shutil.copy2(REAL_HOOK_SOURCE, githooks_dir / "pre-push")
+    return tmp_path
+
+
+class TestSetupPrePushHook:
+    """Test installation of the tracked hook template."""
+
+    def test_copies_hook_content_byte_for_byte(self, fake_project_root: Path):
+        """As a user I want the installed hook to match the tracked template exactly.
+
+        Guards against the pre-#175 bug where the Unix branch copied
+        .git/hooks/pre-push onto itself instead of installing a real template.
+        """
+        assert setup_pre_push_hook(fake_project_root) is True
+
+        installed = fake_project_root / ".git" / "hooks" / "pre-push"
+        assert installed.read_bytes() == REAL_HOOK_SOURCE.read_bytes()
+
+    def test_sets_executable_bit(self, fake_project_root: Path):
+        """Installed hook must be marked executable so git can run it directly."""
+        setup_pre_push_hook(fake_project_root)
+
+        installed = fake_project_root / ".git" / "hooks" / "pre-push"
+        assert os.access(installed, os.X_OK)
+
+    def test_returns_false_when_git_hooks_dir_missing(self, tmp_path: Path):
+        """Fails clearly when not run inside a git repository."""
+        assert setup_pre_push_hook(tmp_path) is False
+
+    def test_returns_false_when_template_missing(self, tmp_path: Path):
+        """Fails clearly when the tracked githooks/pre-push template is absent."""
+        (tmp_path / ".git" / "hooks").mkdir(parents=True)
+        assert setup_pre_push_hook(tmp_path) is False
+
+
+class TestVerifyHookSetup:
+    """Test that verification actually exercises the installed hook.
+
+    As a user I want setup to fail loudly when the hook can't actually run,
+    so I can trust "setup succeeded" instead of discovering a broken hook
+    only when a real push silently skips enforcement (the pre-#175 bug).
+    """
+
+    def test_returns_false_when_hook_missing(self, tmp_path: Path):
+        """No hook installed at all must be reported as not configured."""
+        assert verify_hook_setup(tmp_path) is False
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="Windows has no meaningful X_OK bit — os.access(X_OK) is a no-op there",
+    )
+    def test_returns_false_when_hook_not_executable(self, fake_project_root: Path):
+        """A present but non-executable hook file must be reported as broken."""
+        installed = fake_project_root / ".git" / "hooks" / "pre-push"
+        installed.write_text("#!/bin/sh\nexit 0\n")
+        os.chmod(installed, stat.S_IRUSR | stat.S_IWUSR)  # not executable
+
+        assert verify_hook_setup(fake_project_root) is False
+
+    def test_self_test_executes_successfully_when_interpreter_available(self, fake_project_root: Path):
+        """Verification actually runs the hook (PRE_PUSH_SELF_TEST=1), not just stat() checks."""
+        if shutil.which("sh") is None:
+            pytest.skip("no sh interpreter available on PATH")
+
+        setup_pre_push_hook(fake_project_root)
+
+        assert verify_hook_setup(fake_project_root) is True
+
+    def test_degrades_gracefully_with_no_interpreter_on_path(self, fake_project_root: Path, monkeypatch: pytest.MonkeyPatch):
+        """Missing 'sh' on PATH must warn, not hard-fail — git runs hooks via its own bundled sh."""
+        setup_pre_push_hook(fake_project_root)
+        monkeypatch.setattr(shutil, "which", lambda _name: None)
+
+        assert verify_hook_setup(fake_project_root) is True
+
+    def test_reports_failure_when_hook_script_itself_fails(self, fake_project_root: Path):
+        """A hook that installs cleanly but errors at runtime must fail verification."""
+        if shutil.which("sh") is None:
+            pytest.skip("no sh interpreter available on PATH")
+
+        installed = fake_project_root / ".git" / "hooks" / "pre-push"
+        installed.write_text('#!/bin/sh\necho "boom" >&2\nexit 1\n')
+        os.chmod(installed, stat.S_IRWXU | stat.S_IRGRP | stat.S_IROTH)
+
+        assert verify_hook_setup(fake_project_root) is False


### PR DESCRIPTION
## Summary

Fixes the pre-push hook install so it actually works on a fresh clone, on both Windows and Unix.

- Root cause: the hook logic was never committed to the repo — it only existed as hand-reconstructed, untracked files in this machine's local `.git/hooks/`. On a genuinely fresh clone, the Windows branch wrote a batch wrapper referencing a `pre-push.ps1` that was never generated, and the Unix branch copied `.git/hooks/pre-push` onto itself.
- Added `githooks/pre-push`: a single tracked POSIX script (executable bit set). Git for Windows invokes hooks through its bundled `sh`, so one script works unmodified on both platforms — no OS branch or PowerShell wrapper needed.
- Rewrote `scripts/setup_git_hooks.py` to copy that tracked template into `.git/hooks/pre-push`. `verify_hook_setup()` now actually executes the installed hook via `PRE_PUSH_SELF_TEST=1` instead of only checking existence/executable bit. It only resolves `sh` (never falls back to `bash`), since a generic `bash` lookup risks resolving to an unrelated launcher (e.g. the Windows/WSL bash stub in `System32`) that fails on Windows-style paths and would misreport a working hook as broken.
- Added `tests/test_setup_git_hooks.py` covering install, byte-identical copy, executable bit, self-test execution, and graceful degradation when no `sh` interpreter is on PATH.
- Updated `docs/technical/GIT_HOOKS.md` to describe the tracked-template install flow and fix stale links to untracked `.git/hooks/*` paths.

Closes #175

## Test plan

- [x] `uv run pytest tests/test_setup_git_hooks.py -v` — 8 passed, 1 skipped (skip is platform-specific: Windows has no meaningful `X_OK` bit)
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] Full suite: `uv run pytest -n 8` — 1005 passed, 4 skipped
- [x] Manual fresh-clone simulation: removed `.git/hooks/pre-push{,.ps1}`, reran `uv run python scripts/setup_git_hooks.py`, confirmed real execution (not just a stat check)
- [x] Live test: pushed this branch and confirmed the hook actually ran (`uv sync`, ruff, full fast test suite) before letting the push through

🤖 Generated with [Claude Code](https://claude.com/claude-code)