### PR TITLE
#73: fix: wire embedding provider into IngestionService

### DIFF
--- a/scripts/verify_voice_pipeline.py
+++ b/scripts/verify_voice_pipeline.py
@@ -220,7 +220,7 @@ def run_progression(url: str, ingestion_wait_sec: int = DEFAULT_INGESTION_WAIT_S
                 content = f.read()
             files = {"file": ("metformin_verify_pipeline.txt", content, "text/plain")}
             upload_resp = httpx.post(f"{url}/api/v1/documents", files=files, timeout=30)
-            if upload_resp.status_code == 200:
+            if upload_resp.status_code in (200, 201):
                 if ingestion_wait_sec > 0:
                     log.info("Uploaded metformin doc, waiting %s s for ingestion...", ingestion_wait_sec)
                     time.sleep(ingestion_wait_sec)
@@ -286,19 +286,20 @@ def run_dutch_rag(url: str) -> bool:
     if not check_prerequisites(url, "Dutch->English RAG check"):
         return False
 
-    # Check Ollama
+    # Check Ollama (informational only; the backend uses its own OLLAMA_BASE_URL regardless)
+    ollama_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
     try:
         import httpx
 
         with httpx.Client(timeout=3) as client:
-            r = client.get("http://localhost:11434/api/tags")
+            r = client.get(f"{ollama_url}/api/tags")
             models = r.json().get("models", []) if r.status_code == 200 else []
         if not models:
             log.warning("Ollama has no models. Run: ollama pull mistral:7b")
         else:
             log.info("Ollama models: %s", [m.get("name") for m in models[:5]])
     except Exception as e:
-        log.warning("Ollama not reachable: %s. Dutch->English RAG needs Ollama.", e)
+        log.warning("Ollama not reachable at %s: %s. Dutch->English RAG needs Ollama.", ollama_url, e)
 
     # Dutch medical question
     question_nl = "Wat is de aanbevolen dosering van metformine bij diabetes type 2?"

--- a/src/backend/rag_pipeline/services/document_processing_service.py
+++ b/src/backend/rag_pipeline/services/document_processing_service.py
@@ -16,7 +16,7 @@ from typing import Any
 
 from backend.ingestion.application.ingest_service import IngestionService
 from backend.ingestion.infrastructure.progress import ProgressEvent, progress_notifier
-from backend.rag_pipeline.config.parameter_sets import RAGParams, get_param_set
+from backend.rag_pipeline.config.parameter_sets import DEFAULT_PARAM_SET_NAME, RAGParams, get_param_set
 from backend.rag_pipeline.core.vector_store import get_vector_store_manager
 from backend.rag_pipeline.models.document_models import DocumentMetadata
 from backend.rag_pipeline.utils.logging import StructuredLogger
@@ -28,10 +28,20 @@ _ingestion_service: IngestionService | None = None
 
 
 def _get_ingestion_service() -> IngestionService:
-    """Get or create the shared IngestionService instance."""
+    """Get or create the shared IngestionService instance.
+
+    Wires the default parameter set's embedding model as the ingestion embedding
+    provider — without this, IngestionService silently skips embedding generation
+    (see IngestionService.__init__ docstring) and every uploaded document ends up
+    with 0 vector-store records, breaking retrieval for the whole app.
+    """
     global _ingestion_service
     if _ingestion_service is None:
-        _ingestion_service = IngestionService()
+        from backend.rag_pipeline.utils.embedding_model_utils import get_embedding_model
+
+        default_model_name = get_param_set(DEFAULT_PARAM_SET_NAME).embedding.model_name
+        embedding_provider = get_embedding_model(default_model_name)
+        _ingestion_service = IngestionService(embedding_provider=embedding_provider)  # type: ignore[arg-type]
     return _ingestion_service
 
 


### PR DESCRIPTION
## Summary
- **Fixes a P0 bug found while verifying #73**: `IngestionService` was constructed with no embedding provider, so every uploaded document was chunked but never embedded — `records_stored: 0` on every ingest, meaning every RAG query in the running app returned "no relevant information" regardless of content. Wired the same `get_embedding_model()` factory the retrieval path already uses.
- Fixes two bugs in `scripts/verify_voice_pipeline.py` (existing TTS/STT verification automation) surfaced during testing: upload status check expected 200 but the API returns 201 (silently skipped RAG steps every run); Ollama reachability check hardcoded `localhost` instead of respecting `OLLAMA_BASE_URL`.

Full verification writeup: #73 (issue comment).

## Test plan
- [x] Fresh document upload → `records_stored: 1` (was 0 before fix)
- [x] `POST /api/v1/qa` returns grounded, cited answer (confidence: high, similarity: 1.0)
- [x] `POST /api/v1/qa/voice` (TTS-generated audio → transcribe → RAG) returns cited answer end-to-end
- [x] `ruff check` / `ruff format --check` clean (run inside backend container; local Windows venv has an unrelated `annoy` build-tools gap)
- [ ] UI walkthrough not done this session (Chrome extension unavailable) — recommend a manual pass at http://localhost:5173