### PR TITLE
docs: link production-agentic-rag-course as related project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,10 @@ Open issues are tracked on a GitHub Project (Kanban board): https://github.com/u
 
 Use `tmp/` (gitignored) for all scratch files — never the repo root or `docs/`. See [tmp/CLAUDE.md](tmp/CLAUDE.md) for subdirectory layout and conventions.
 
+## Related Projects
+
+Sibling repo `../production-agentic-rag-course` ([pkuppens/production-agentic-rag-course](https://github.com/pkuppens/production-agentic-rag-course.git)) is a learning course building a production-grade RAG system (OpenSearch, hybrid search, LangGraph agentic RAG, Airflow) from scratch. It's a source of lessons and techniques to evaluate for adoption here — check it for prior art before designing new retrieval, agentic, or pipeline features. This project does not need to reciprocally track it, but improvements made here may be worth porting back.
+
 ## References
 
 | Topic | Location |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,10 +105,6 @@ Open issues are tracked on a GitHub Project (Kanban board): https://github.com/u
 
 Use `tmp/` (gitignored) for all scratch files — never the repo root or `docs/`. See [tmp/CLAUDE.md](tmp/CLAUDE.md) for subdirectory layout and conventions.
 
-## Related Projects
-
-Sibling repo `../production-agentic-rag-course` ([pkuppens/production-agentic-rag-course](https://github.com/pkuppens/production-agentic-rag-course.git)) is a learning course building a production-grade RAG system (OpenSearch, hybrid search, LangGraph agentic RAG, Airflow) from scratch. It's a source of lessons and techniques to evaluate for adoption here — check it for prior art before designing new retrieval, agentic, or pipeline features. This project does not need to reciprocally track it, but improvements made here may be worth porting back.
-
 ## References
 
 | Topic | Location |

--- a/README.md
+++ b/README.md
@@ -233,6 +233,10 @@ Key architectural trade-offs that shape the system:
 
 For legal, commercial, and pending decisions, see [Key Business Concerns & Decisions](#key-business-concerns--decisions).
 
+## Related Projects
+
+Sibling repo [production-agentic-rag-course](https://github.com/pkuppens/production-agentic-rag-course.git) is a hands-on course building a production-grade RAG system (OpenSearch hybrid search, LangGraph agentic RAG, Airflow pipelines) from the ground up. It serves as a source of techniques and lessons learned to evaluate for adoption in this project; the relationship is one-directional for now, though improvements made here may later be worth porting back there.
+
 ## What We'll Build
 
 ![image](https://github.com/user-attachments/assets/2ed5872e-9ab2-49e4-90bf-ca0f774a46e1)


### PR DESCRIPTION
## Summary
- Adds a "Related Projects" section to CLAUDE.md and README.md cross-referencing the sibling `production-agentic-rag-course` repo
- Notes it as a source of RAG techniques/lessons to evaluate for adoption in this project (one-directional relationship)

## Test plan
- [x] Docs-only change; no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)