### PR TITLE
#208: fix: prevent duplicate chunk IDs and dead-code dedup check in ingestion

### DIFF
--- a/src/backend/ingestion/infrastructure/chunking.py
+++ b/src/backend/ingestion/infrastructure/chunking.py
@@ -245,8 +245,8 @@ def chunk_documents(
             text_cleaning_stats["cleaned_chunks"] += len(page_chunks)
 
         # Convert nodes to domain Chunks
-        for i, node in enumerate(page_chunks):
-            chunk_index = len(all_chunks) + i
+        for node in page_chunks:
+            chunk_index = len(all_chunks)
             doc_id = f"{source_path.stem}_{chunk_index}"
             domain_chunk = Chunk(
                 text=node.text or "",

--- a/src/backend/ingestion/infrastructure/vector_store.py
+++ b/src/backend/ingestion/infrastructure/vector_store.py
@@ -111,7 +111,7 @@ class ChromaVectorStoreWriteAdapter(IVectorStoreWrite):
         try:
             where: dict[str, Any] = {"file_content_hash": file_content_hash}
             if embedding_model:
-                where["embedding_model"] = embedding_model
+                where = {"$and": [{"file_content_hash": file_content_hash}, {"embedding_model": embedding_model}]}
             result = self._collection.get(
                 where=where,
                 include=[],

--- a/src/backend/rag_pipeline/core/vector_store.py
+++ b/src/backend/rag_pipeline/core/vector_store.py
@@ -132,7 +132,7 @@ class ChromaVectorStoreManager(VectorStoreManager):
         try:
             where: dict = {"file_content_hash": file_content_hash}
             if embedding_model:
-                where["embedding_model"] = embedding_model
+                where = {"$and": [{"file_content_hash": file_content_hash}, {"embedding_model": embedding_model}]}
             result = self._collection.get(
                 where=where,
                 include=[],

--- a/tests/test_ingestion_chunking.py
+++ b/tests/test_ingestion_chunking.py
@@ -158,6 +158,29 @@ class TestChunkDocuments:
             assert chunk1.page_number == chunk2.page_number
             assert chunk1.document_name == chunk2.document_name
 
+    def test_chunk_ids_unique_across_uneven_pages(self):
+        """Regression test for #207: chunk_index must not double-count position.
+
+        A document whose pages produce different chunk counts (e.g. 7, 6, 2)
+        previously produced duplicate document_id/chunk_index values across
+        page boundaries (chunk_index = len(all_chunks) + i), which crashed
+        ChromaDB's collection.add() with DuplicateIDError and silently
+        dropped the whole document from the vector store.
+        """
+        documents = [
+            IngestionDocument(text=". ".join(f"Sentence {i} on page one" for i in range(60))),
+            IngestionDocument(text=". ".join(f"Sentence {i} on page two" for i in range(50))),
+            IngestionDocument(text=". ".join(f"Sentence {i} on page three" for i in range(15))),
+        ]
+
+        chunks = chunk_documents(documents, source_path=Path("test.pdf"), chunk_size=50, chunk_overlap=5)
+
+        document_ids = [c.document_id for c in chunks]
+        assert len(document_ids) == len(set(document_ids)), f"Duplicate document_id values: {document_ids}"
+
+        chunk_indices = [c.chunk_index for c in chunks]
+        assert chunk_indices == list(range(len(chunks))), f"chunk_index must be a contiguous sequence, got {chunk_indices}"
+
     def test_empty_page_handling(self):
         """Test that empty pages are properly marked and preserved for page numbering."""
         documents = [

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -20,6 +20,14 @@ from rag_pipeline.core.vector_store import ChromaVectorStoreManager
 class TestChromaVectorStoreManager:
     """Test ChromaDB vector store manager."""
 
+    @pytest.fixture(autouse=True)
+    def _release_manager_on_windows(self):
+        """Cleanup to release ChromaDB/SQLite file locks on Windows after each test."""
+        yield
+        import gc
+
+        gc.collect()
+
     def test_add_and_query(self, test_case_dir):
         """Test adding and querying embeddings."""
         config = VectorStoreConfig(host=None, persist_directory=str(test_case_dir))
@@ -35,12 +43,6 @@ class TestChromaVectorStoreManager:
         assert isinstance(ids, list), f"Expected ids to be list, got {type(ids)}"
         assert len(ids) == 1, f"Expected 1 id, got {len(ids)}"
         assert ids[0] == "1", f"Expected first id to be '1', got '{ids[0]}'"
-
-        # Cleanup to release file locks on Windows
-        del manager
-        import gc
-
-        gc.collect()
 
     def test_get_chunk_count_and_get_all_chunks(self, test_case_dir):
         """As a user I want metrics and BM25 to use the abstract interface.
@@ -63,11 +65,6 @@ class TestChromaVectorStoreManager:
         assert len(metadatas) == 2
         assert metadatas[0].get("chunk_index") == 0
 
-        del manager
-        import gc
-
-        gc.collect()
-
     def test_has_document_with_file_hash_scoped_by_embedding_model(self, test_case_dir):
         """Regression test for #207: has_document_with_file_hash must not always return False.
 
@@ -89,8 +86,3 @@ class TestChromaVectorStoreManager:
         assert manager.has_document_with_file_hash("abc123", embedding_model="model-a") is True
         assert manager.has_document_with_file_hash("abc123", embedding_model="model-b") is False
         assert manager.has_document_with_file_hash("other-hash", embedding_model="model-a") is False
-
-        del manager
-        import gc
-
-        gc.collect()

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -67,3 +67,30 @@ class TestChromaVectorStoreManager:
         import gc
 
         gc.collect()
+
+    def test_has_document_with_file_hash_scoped_by_embedding_model(self, test_case_dir):
+        """Regression test for #207: has_document_with_file_hash must not always return False.
+
+        Passing both file_content_hash and embedding_model previously built a flat
+        two-key ChromaDB `where` dict, which ChromaDB rejects with ValueError
+        ("Expected where to have exactly one operator"). The bare except-Exception
+        swallowed that error and always returned False, silently disabling
+        duplicate-content detection for every ingest that specifies an embedding model.
+        """
+        config = VectorStoreConfig(host=None, persist_directory=str(test_case_dir), collection_name="test_dedup")
+        manager = ChromaVectorStoreManager(config)
+
+        manager.add_embeddings(
+            ids=["c1"],
+            embeddings=[[0.1, 0.2]],
+            metadatas=[{"file_content_hash": "abc123", "embedding_model": "model-a"}],
+        )
+
+        assert manager.has_document_with_file_hash("abc123", embedding_model="model-a") is True
+        assert manager.has_document_with_file_hash("abc123", embedding_model="model-b") is False
+        assert manager.has_document_with_file_hash("other-hash", embedding_model="model-a") is False
+
+        del manager
+        import gc
+
+        gc.collect()


### PR DESCRIPTION
## Summary

Fixes #208 — document ingestion silently failed to store chunks/embeddings for multi-page PDFs.

- **`src/backend/ingestion/infrastructure/chunking.py`**: `chunk_index` was computed as `len(all_chunks) + i`, double-counting position since `all_chunks` already grows by one per loop iteration. This produced colliding chunk IDs across page boundaries whenever a document's per-page chunk counts didn't align, crashing ChromaDB's `add()` with `DuplicateIDError` inside the fire-and-forget background task — the document silently ends up with 0 stored chunks despite the API returning a 201 "success" response.
- **`src/backend/ingestion/infrastructure/vector_store.py`** and **`src/backend/rag_pipeline/core/vector_store.py`**: `has_document_with_file_hash` built a flat two-key ChromaDB `where` filter when `embedding_model` was passed. This ChromaDB version requires multi-key filters wrapped in `$and`, so it raised `ValueError`, silently swallowed by a bare `except Exception: return False` — duplicate-content detection was effectively dead code.

Full root-cause analysis, suggested fix, acceptance criteria, and verification results are in #208.

## Verification results

Reproduced and fixed against the two real multi-page PDFs from the bug report:

| Step | Result |
|---|---|
| Ingest doc 1 (3 pages, 15 chunks) | success, 15 records stored |
| Ingest doc 2 (16 chunks) | success, 16 records stored |
| Vector store count | 31, all unique IDs |
| Re-ingest same files (idempotency) | correctly detected as duplicate, 0 chunks reprocessed, count stays 31 |
| Delete both documents | 15 + 16 chunks deleted, count → 0 |
| Re-ingest from scratch after delete | 15 + 16 chunks stored again, count → 31 |
| `test_ingestion_chunking.py`, `test_chunking.py`, `test_vector_store.py`, `test_document_routes.py` | 40/40 passed |

Added regression tests for both root causes:
- `test_chunk_ids_unique_across_uneven_pages`
- `test_has_document_with_file_hash_scoped_by_embedding_model`

## Test plan

- [x] `uv run pytest tests/test_ingestion_chunking.py tests/test_chunking.py tests/test_vector_store.py tests/test_document_routes.py` — 40/40 passed
- [x] `uv run ruff check --fix .` / `uv run ruff format .` — clean
- [x] Manually verified ingest → idempotent re-ingest → delete → re-ingest-from-scratch cycle against the real vector store

🤖 Generated with [Claude Code](https://claude.com/claude-code)